### PR TITLE
nixosProfiles.nixを機能別モジュールに分割

### DIFF
--- a/cells/core/nixosProfiles/base.nix
+++ b/cells/core/nixosProfiles/base.nix
@@ -1,0 +1,50 @@
+# cells/core/nixosProfiles/base.nix
+{ inputs, cell }:
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+{
+  system.stateVersion = "21.11";
+  system.autoUpgrade.enable = false;
+  system.autoUpgrade.allowReboot = false;
+
+  nix.extraOptions = ''
+    experimental-features = nix-command flakes
+  '';
+
+  boot.loader.systemd-boot.enable = true;
+  boot.loader.efi.canTouchEfiVariables = true;
+
+  time.timeZone = "Asia/Tokyo";
+
+  users.users.bunbun = {
+    isNormalUser = true;
+    extraGroups = [
+      "wheel"
+      "docker"
+    ];
+    shell = pkgs.zsh;
+    # authorizedKeys.keyFilesはprofileごとに上書き
+  };
+
+  programs.zsh.enable = true;
+
+  environment.systemPackages = with pkgs; [
+    vim
+    wget
+  ];
+
+  virtualisation = {
+    vmVariantWithBootLoader = {
+      virtualisation = {
+        memorySize = 2048;
+        cores = 2;
+        graphics = false;
+        useEFIBoot = true;
+      };
+    };
+  };
+}

--- a/cells/core/nixosProfiles/kubernetes.nix
+++ b/cells/core/nixosProfiles/kubernetes.nix
@@ -1,0 +1,15 @@
+# cells/core/nixosProfiles/kubernetes.nix
+{ inputs, cell }:
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+{
+  environment.systemPackages = with pkgs; [
+    kompose
+    kubectl
+    kubernetes
+  ];
+}

--- a/cells/core/nixosProfiles/networking.nix
+++ b/cells/core/nixosProfiles/networking.nix
@@ -1,0 +1,40 @@
+# cells/core/nixosProfiles/networking.nix
+{ inputs, cell }:
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  kubeMasterIP = "192.168.1.3";
+  kubeMasterHostname = "api.kube";
+in
+{
+  networking.hostName = "nixos";
+  networking.domain = "shinbunbun.com";
+  networking.useDHCP = false;
+  networking.interfaces.eno1.useDHCP = true;
+  networking.interfaces.wlp1s0.useDHCP = false;
+  networking.enableIPv6 = true;
+
+  networking.firewall.allowedTCPPorts = [
+    6443 # Kubernetes API
+    8888 # General purpose
+    2049 # NFS
+  ];
+
+  networking.extraHosts = ''
+    ${kubeMasterIP} ${kubeMasterHostname}
+    192.168.1.4 nixos-desktop
+  '';
+
+  services.avahi = {
+    enable = true;
+    publish = {
+      enable = true;
+      addresses = true;
+      workstation = true;
+    };
+  };
+}

--- a/cells/core/nixosProfiles/security.nix
+++ b/cells/core/nixosProfiles/security.nix
@@ -1,0 +1,48 @@
+# cells/core/nixosProfiles/security.nix
+{ inputs, cell }:
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  sopsWireGuardHelper = import ../sops-wireguard.nix { inherit inputs cell; };
+in
+{
+  # PAM設定
+  security.pam.services = {
+    sudo.sshAgentAuth = true;
+  };
+
+  # Polkit
+  security.polkit.enable = true;
+
+  # SOPS設定
+  sops = {
+    defaultSopsFile = "${inputs.self}/secrets/ssh-keys.yaml";
+    age.keyFile = "/var/lib/sops-nix/key.txt";
+
+    secrets."ssh_keys/bunbun" = {
+      path = "/etc/ssh/authorized_keys.d/bunbun";
+      owner = "bunbun";
+      group = "wheel";
+      mode = "0444";
+      neededForUsers = true;
+    };
+  };
+}
+// (
+  # WireGuard設定を共通モジュールから適用
+  sopsWireGuardHelper.mkSopsWireGuardConfig { inherit config pkgs lib; } {
+    sopsFile = "${inputs.self}/secrets/wireguard.yaml";
+    privateKeyPath = "wireguard/home/nixosClientPrivKey";
+    publicKeyPath = "wireguard/home/publicKey";
+    interfaceName = "wg0";
+    interfaceAddress = "10.100.0.4/24";
+    peerEndpoint = "192.168.1.1:13231";
+    peerAllowedIPs = [ "10.100.0.1/32" ];
+    persistentKeepalive = 25;
+    isDarwin = false;
+  }
+)

--- a/cells/core/nixosProfiles/services.nix
+++ b/cells/core/nixosProfiles/services.nix
@@ -1,0 +1,42 @@
+# cells/core/nixosProfiles/services.nix
+{ inputs, cell }:
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+{
+  # SSH service
+  services.openssh = {
+    enable = true;
+    ports = [ 31415 ];
+    settings = {
+      X11Forwarding = true;
+      PermitRootLogin = "no";
+      PasswordAuthentication = false;
+    };
+    extraConfig = ''
+      AuthorizedKeysFile /etc/ssh/authorized_keys.d/%u
+    '';
+  };
+
+  # Fail2ban for SSH protection
+  services.fail2ban = {
+    enable = true;
+    ignoreIP = [
+      "192.168.11.0/24"
+      "163.143.0.0/16"
+    ];
+  };
+
+  # Docker
+  virtualisation.docker.enable = true;
+
+  # NFS server
+  services.nfs.server.enable = true;
+  services.nfs.server.exports = ''
+    /export/k8s  192.168.1.4(rw,nohide,insecure,no_subtree_check,no_root_squash)
+    /export/k8s  192.168.1.3(rw,nohide,insecure,no_subtree_check,no_root_squash)
+  '';
+}

--- a/cells/core/nixosProfiles/system-tools.nix
+++ b/cells/core/nixosProfiles/system-tools.nix
@@ -1,0 +1,14 @@
+# cells/core/nixosProfiles/system-tools.nix
+{ inputs, cell }:
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+{
+  environment.systemPackages = with pkgs; [
+    polkit
+    wireguard-tools
+  ];
+}


### PR DESCRIPTION
## 概要
nixosProfiles.nixが191行と大きくなっていたため、機能別に分割しました。

## 変更内容
以下の6つのモジュールに分割：
- `base.nix`: 基本システム設定（boot、nix、ユーザー）
- `networking.nix`: ネットワーク設定（ファイアウォール、Avahi）
- `services.nix`: サービス設定（SSH、Docker、NFS）
- `security.nix`: セキュリティ設定（PAM、Polkit、SOPS、WireGuard）
- `kubernetes.nix`: Kubernetesツール
- `system-tools.nix`: システムツール

## 互換性
- 既存の`default`プロファイルは全モジュールをインポートするため、使用方法に変更なし
- 必要に応じて個別のモジュールを選択的に使用可能

## 確認事項
- [x] `nix flake check`が通過
- [x] `nixos-rebuild switch`で動作確認