### PR TITLE
dev/homeProfilesを機能別モジュールに分割

### DIFF
--- a/cells/dev/homeProfiles.nix
+++ b/cells/dev/homeProfiles.nix
@@ -1,121 +1,26 @@
+# cells/dev/homeProfiles.nix
 {
   inputs,
   cell,
 }:
 {
-  git = {
-    programs.git = {
-      enable = true;
+  # 分割されたモジュール
+  git = import ./homeProfiles/version-control.nix { inherit inputs cell; };
+  zsh = import ./homeProfiles/shell-tools.nix { inherit inputs cell; };
+  vim = import ./homeProfiles/editors.nix { inherit inputs cell; };
+  google_cloud_sdk = import ./homeProfiles/cloud-tools.nix { inherit inputs cell; };
+  manage_secrets = import ./homeProfiles/security-tools.nix { inherit inputs cell; };
+  cocoapods = import ./homeProfiles/development-tools.nix { inherit inputs cell; };
+  claude_code = import ./homeProfiles/ai-tools.nix { inherit inputs cell; };
 
-      userName = "shinbunbun";
-      userEmail = "34409044+shinbunbun@users.noreply.github.com";
-
-      extraConfig = {
-        core.editor = "code --wait";
-      };
-    };
-  };
-
-  zsh =
-    { pkgs, ... }:
-    {
-      # zsh config
-      programs.zsh = {
-        enable = true;
-        enableCompletion = true;
-        autosuggestion.enable = true;
-        plugins = [
-          {
-            name = "zsh-completions";
-            src = pkgs.zsh-completions.src;
-          }
-          {
-            name = "nix-zsh-completions";
-            src = pkgs.nix-zsh-completions.src;
-          }
-        ];
-      };
-
-      # LSD config
-      programs.lsd = {
-        enable = true;
-      };
-
-      # starship config
-      programs.starship = {
-        enable = true;
-        settings = {
-          status = {
-            disabled = false;
-          };
-          time = {
-            disabled = false;
-            utc_time_offset = "+9";
-            time_format = "%Y-%m-%d %H:%M";
-          };
-        };
-      };
-
-      # direnv config
-      programs.direnv = {
-        enable = true;
-        nix-direnv.enable = true;
-        enableBashIntegration = true;
-      };
-    };
-
-  vim =
-    { pkgs, ... }:
-    {
-      # vim config
-      programs.vim = {
-        enable = true;
-        plugins = with pkgs.vimPlugins; [ vim-airline ];
-      };
-    };
-
-  google_cloud_sdk =
-    { pkgs, ... }:
-    let
-      google-cloud-sdk-with-cloud-datastore-emulator = pkgs.google-cloud-sdk.withExtraComponents ([
-        pkgs.google-cloud-sdk.components.cloud-datastore-emulator
-      ]);
-    in
-    {
-      home.packages = with pkgs; [
-        google-cloud-sdk-with-cloud-datastore-emulator
-      ];
-    };
-
-  manage_secrets =
-    { pkgs, ... }:
-    {
-      home.packages = with pkgs; [
-        age
-        sops
-      ];
-    };
-
-  cocoapods =
-    { pkgs, ... }:
-    {
-      home.packages = with pkgs; [
-        cocoapods
-      ];
-    };
-
-  claude_code =
-    { pkgs, ... }:
-    {
-      home.packages = with pkgs; [
-        claude-code
-      ];
-      home.file.".claude/CLAUDE.md" = {
-        text = ''
-          ユーザーには日本語で応答してください。
-        '';
-      };
-    };
+  # エイリアス（互換性のため）
+  versionControl = import ./homeProfiles/version-control.nix { inherit inputs cell; };
+  shellTools = import ./homeProfiles/shell-tools.nix { inherit inputs cell; };
+  editors = import ./homeProfiles/editors.nix { inherit inputs cell; };
+  cloudTools = import ./homeProfiles/cloud-tools.nix { inherit inputs cell; };
+  securityTools = import ./homeProfiles/security-tools.nix { inherit inputs cell; };
+  developmentTools = import ./homeProfiles/development-tools.nix { inherit inputs cell; };
+  aiTools = import ./homeProfiles/ai-tools.nix { inherit inputs cell; };
 
   /*
     graphql =

--- a/cells/dev/homeProfiles/ai-tools.nix
+++ b/cells/dev/homeProfiles/ai-tools.nix
@@ -1,0 +1,14 @@
+# cells/dev/homeProfiles/ai-tools.nix
+{ inputs, cell }:
+{ pkgs, ... }:
+{
+  home.packages = with pkgs; [
+    claude-code
+  ];
+
+  home.file.".claude/CLAUDE.md" = {
+    text = ''
+      ユーザーには日本語で応答してください。
+    '';
+  };
+}

--- a/cells/dev/homeProfiles/cloud-tools.nix
+++ b/cells/dev/homeProfiles/cloud-tools.nix
@@ -1,0 +1,13 @@
+# cells/dev/homeProfiles/cloud-tools.nix
+{ inputs, cell }:
+{ pkgs, ... }:
+let
+  google-cloud-sdk-with-cloud-datastore-emulator = pkgs.google-cloud-sdk.withExtraComponents ([
+    pkgs.google-cloud-sdk.components.cloud-datastore-emulator
+  ]);
+in
+{
+  home.packages = with pkgs; [
+    google-cloud-sdk-with-cloud-datastore-emulator
+  ];
+}

--- a/cells/dev/homeProfiles/development-tools.nix
+++ b/cells/dev/homeProfiles/development-tools.nix
@@ -1,0 +1,8 @@
+# cells/dev/homeProfiles/development-tools.nix
+{ inputs, cell }:
+{ pkgs, ... }:
+{
+  home.packages = with pkgs; [
+    cocoapods
+  ];
+}

--- a/cells/dev/homeProfiles/editors.nix
+++ b/cells/dev/homeProfiles/editors.nix
@@ -1,0 +1,10 @@
+# cells/dev/homeProfiles/editors.nix
+{ inputs, cell }:
+{ pkgs, ... }:
+{
+  # vim config
+  programs.vim = {
+    enable = true;
+    plugins = with pkgs.vimPlugins; [ vim-airline ];
+  };
+}

--- a/cells/dev/homeProfiles/security-tools.nix
+++ b/cells/dev/homeProfiles/security-tools.nix
@@ -1,0 +1,9 @@
+# cells/dev/homeProfiles/security-tools.nix
+{ inputs, cell }:
+{ pkgs, ... }:
+{
+  home.packages = with pkgs; [
+    age
+    sops
+  ];
+}

--- a/cells/dev/homeProfiles/shell-tools.nix
+++ b/cells/dev/homeProfiles/shell-tools.nix
@@ -1,0 +1,48 @@
+# cells/dev/homeProfiles/shell-tools.nix
+{ inputs, cell }:
+{ pkgs, ... }:
+{
+  # zsh config
+  programs.zsh = {
+    enable = true;
+    enableCompletion = true;
+    autosuggestion.enable = true;
+    plugins = [
+      {
+        name = "zsh-completions";
+        src = pkgs.zsh-completions.src;
+      }
+      {
+        name = "nix-zsh-completions";
+        src = pkgs.nix-zsh-completions.src;
+      }
+    ];
+  };
+
+  # LSD config
+  programs.lsd = {
+    enable = true;
+  };
+
+  # starship config
+  programs.starship = {
+    enable = true;
+    settings = {
+      status = {
+        disabled = false;
+      };
+      time = {
+        disabled = false;
+        utc_time_offset = "+9";
+        time_format = "%Y-%m-%d %H:%M";
+      };
+    };
+  };
+
+  # direnv config
+  programs.direnv = {
+    enable = true;
+    nix-direnv.enable = true;
+    enableBashIntegration = true;
+  };
+}

--- a/cells/dev/homeProfiles/version-control.nix
+++ b/cells/dev/homeProfiles/version-control.nix
@@ -1,0 +1,15 @@
+# cells/dev/homeProfiles/version-control.nix
+{ inputs, cell }:
+{ pkgs, ... }:
+{
+  programs.git = {
+    enable = true;
+
+    userName = "shinbunbun";
+    userEmail = "34409044+shinbunbun@users.noreply.github.com";
+
+    extraConfig = {
+      core.editor = "code --wait";
+    };
+  };
+}


### PR DESCRIPTION
## 概要
dev/homeProfiles.nixを機能別に分割し、より管理しやすい構造にしました。

## 変更内容
以下の7つのモジュールに分割：
- `version-control.nix`: Git設定
- `shell-tools.nix`: シェル関連ツール（zsh、starship、direnv、lsd）
- `editors.nix`: エディタ設定（vim）
- `cloud-tools.nix`: クラウドツール（Google Cloud SDK）
- `security-tools.nix`: セキュリティツール（age、sops）
- `development-tools.nix`: 開発ツール（cocoapods）
- `ai-tools.nix`: AIツール（claude-code）

## 互換性
- 既存の名前（git、zsh、vim等）での参照は維持
- 新しい名前（versionControl、shellTools等）でも参照可能

## 確認事項
- [x] `nix flake check`が通過
- [x] `nixos-rebuild switch`で動作確認済み