### PR TITLE
Kubernetes/NFS設定を独立モジュールに分割

### DIFF
--- a/cells/core/nixosProfiles.nix
+++ b/cells/core/nixosProfiles.nix
@@ -7,6 +7,7 @@
   services = import ./nixosProfiles/services.nix { inherit inputs cell; };
   security = import ./nixosProfiles/security.nix { inherit inputs cell; };
   kubernetes = import ./nixosProfiles/kubernetes.nix { inherit inputs cell; };
+  nfs = import ./nixosProfiles/nfs.nix { inherit inputs cell; };
   systemTools = import ./nixosProfiles/system-tools.nix { inherit inputs cell; };
 
   # 既存のモジュール
@@ -56,6 +57,7 @@
         cell.nixosProfiles.services
         cell.nixosProfiles.security
         cell.nixosProfiles.kubernetes
+        cell.nixosProfiles.nfs
         cell.nixosProfiles.systemTools
       ];
     };

--- a/cells/core/nixosProfiles/kubernetes.nix
+++ b/cells/core/nixosProfiles/kubernetes.nix
@@ -6,10 +6,25 @@
   lib,
   ...
 }:
+let
+  kubeMasterIP = "192.168.1.3";
+  kubeMasterHostname = "api.kube";
+in
 {
+  # Kubernetes tools
   environment.systemPackages = with pkgs; [
     kompose
     kubectl
     kubernetes
   ];
+
+  # Kubernetes API port
+  networking.firewall.allowedTCPPorts = [
+    6443 # Kubernetes API
+  ];
+
+  # Kubernetes hosts configuration
+  networking.extraHosts = ''
+    ${kubeMasterIP} ${kubeMasterHostname}
+  '';
 }

--- a/cells/core/nixosProfiles/networking.nix
+++ b/cells/core/nixosProfiles/networking.nix
@@ -6,10 +6,6 @@
   lib,
   ...
 }:
-let
-  kubeMasterIP = "192.168.1.3";
-  kubeMasterHostname = "api.kube";
-in
 {
   networking.hostName = "nixos";
   networking.domain = "shinbunbun.com";
@@ -19,13 +15,10 @@ in
   networking.enableIPv6 = true;
 
   networking.firewall.allowedTCPPorts = [
-    6443 # Kubernetes API
     8888 # General purpose
-    2049 # NFS
   ];
 
   networking.extraHosts = ''
-    ${kubeMasterIP} ${kubeMasterHostname}
     192.168.1.4 nixos-desktop
   '';
 

--- a/cells/core/nixosProfiles/nfs.nix
+++ b/cells/core/nixosProfiles/nfs.nix
@@ -1,0 +1,21 @@
+# cells/core/nixosProfiles/nfs.nix
+{ inputs, cell }:
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+{
+  # NFS server configuration
+  services.nfs.server.enable = true;
+  services.nfs.server.exports = ''
+    /export/k8s  192.168.1.4(rw,nohide,insecure,no_subtree_check,no_root_squash)
+    /export/k8s  192.168.1.3(rw,nohide,insecure,no_subtree_check,no_root_squash)
+  '';
+
+  # Open NFS port in firewall
+  networking.firewall.allowedTCPPorts = [
+    2049 # NFS
+  ];
+}

--- a/cells/core/nixosProfiles/services.nix
+++ b/cells/core/nixosProfiles/services.nix
@@ -32,11 +32,4 @@
 
   # Docker
   virtualisation.docker.enable = true;
-
-  # NFS server
-  services.nfs.server.enable = true;
-  services.nfs.server.exports = ''
-    /export/k8s  192.168.1.4(rw,nohide,insecure,no_subtree_check,no_root_squash)
-    /export/k8s  192.168.1.3(rw,nohide,insecure,no_subtree_check,no_root_squash)
-  '';
 }


### PR DESCRIPTION
## 概要
Kubernetes関連とNFS設定が複数ファイルに分散していたため、それぞれ独立したモジュールに整理しました。

## 変更内容

### kubernetes.nix の拡張
- Kubernetesツール（kompose、kubectl、kubernetes）
- Kubernetes APIポート設定（6443）
- Kubernetesホスト設定（kubeMasterIP、kubeMasterHostname）

### nfs.nix の新規作成
- NFSサーバー設定
- エクスポート設定（/export/k8s）
- NFSポート設定（2049）

### 移動元
- networking.nix: Kubernetes関連のホスト設定とポート設定を削除
- services.nix: NFS設定を削除

## 利点
- Kubernetes/NFS設定が独立し、管理しやすくなった
- 必要に応じて個別にモジュールを使用可能
- 設定の見通しが向上

## 確認事項
- [x] `nix flake check`が通過
- [x] `nixos-rebuild switch`で動作確認済み