### PR TITLE
Auto-update flake.lock

### DIFF
--- a/cells/toplevel/nixosConfigurations.nix
+++ b/cells/toplevel/nixosConfigurations.nix
@@ -24,26 +24,25 @@ in
       };
     */
 
-    imports =
-      [
-        inputs.cells.core.nixosProfiles.default
-        inputs.cells.core.nixosProfiles.optimise
-        inputs.cells.core.nixosProfiles.obsidian-livesync
+    imports = [
+      inputs.cells.core.nixosProfiles.default
+      inputs.cells.core.nixosProfiles.optimise
+      inputs.cells.core.nixosProfiles.obsidian-livesync
 
-        inputs.home-manager.nixosModules.home-manager
-        inputs.sops-nix.nixosModules.sops
-      ]
-      ++ (
-        if isVM then
-          [
-            inputs.cells.core.nixosProfiles.vm
-          ]
-        else
-          [
-            ./hardwareConfigurations/homeMachine.nix
-            # inputs.cells.core.nixosProfiles.sops
-          ]
-      );
+      inputs.home-manager.nixosModules.home-manager
+      inputs.sops-nix.nixosModules.sops
+    ]
+    ++ (
+      if isVM then
+        [
+          inputs.cells.core.nixosProfiles.vm
+        ]
+      else
+        [
+          ./hardwareConfigurations/homeMachine.nix
+          # inputs.cells.core.nixosProfiles.sops
+        ]
+    );
 
     home-manager = {
       useGlobalPkgs = true;

--- a/flake.lock
+++ b/flake.lock
@@ -295,11 +295,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752814804,
-        "narHash": "sha256-irfg7lnfEpJY+3Cffkluzp2MTVw1Uq9QGxFp6qadcXI=",
+        "lastModified": 1753132348,
+        "narHash": "sha256-0i3jU9AHuNXb0wYGzImnVwaw+miE0yW13qfjC0F+fIE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d0300c8808e41da81d6edfc202f3d3833c157daf",
+        "rev": "e4bf85da687027cfc4a8853ca11b6b86ce41d732",
         "type": "github"
       },
       "original": {
@@ -428,11 +428,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1752687322,
-        "narHash": "sha256-RKwfXA4OZROjBTQAl9WOZQFm7L8Bo93FQwSJpAiSRvo=",
+        "lastModified": 1752950548,
+        "narHash": "sha256-NS6BLD0lxOrnCiEOcvQCDVPXafX1/ek1dfJHX1nUIzc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6e987485eb2c77e5dcc5af4e3c70843711ef9251",
+        "rev": "c87b95e25065c028d31a94f06a62927d18763fdf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This PR updates flake.lock with the latest input updates via `nix flake update`.

Please review and merge if everything looks OK.