### PR TITLE
WireGuard設定の完全共通化

### DIFF
--- a/cells/core/config.nix
+++ b/cells/core/config.nix
@@ -68,7 +68,7 @@
       subnet = "10.100.0.0/24";
       serverIp = "10.100.0.1";
     };
-    
+
     # NixOS用設定
     nixos = {
       interfaceName = "wg0";
@@ -77,7 +77,7 @@
       privateKeyPath = "wireguard/home/nixosClientPrivKey";
       publicKeyPath = "wireguard/home/publicKey";
     };
-    
+
     # Darwin(macOS)用設定
     darwin = {
       interfaceName = "wg-home";
@@ -90,7 +90,7 @@
         "10.100.0.0/24"
       ];
     };
-    
+
     # 共通のkeepalive設定
     persistentKeepalive = 25;
   };

--- a/cells/core/config.nix
+++ b/cells/core/config.nix
@@ -60,4 +60,38 @@
     ];
     options = "rw,nohide,insecure,no_subtree_check,no_root_squash";
   };
+
+  # WireGuard設定
+  wireguard = {
+    # 共通設定
+    network = {
+      subnet = "10.100.0.0/24";
+      serverIp = "10.100.0.1";
+    };
+    
+    # NixOS用設定
+    nixos = {
+      interfaceName = "wg0";
+      clientIp = "10.100.0.4";
+      serverEndpoint = "192.168.1.1:13231";
+      privateKeyPath = "wireguard/home/nixosClientPrivKey";
+      publicKeyPath = "wireguard/home/publicKey";
+    };
+    
+    # Darwin(macOS)用設定
+    darwin = {
+      interfaceName = "wg-home";
+      clientIp = "10.100.0.2";
+      privateKeyPath = "wireguard/home/macClientPrivKey";
+      publicKeyPath = "wireguard/home/publicKey";
+      endpointPath = "wireguard/home/endpoint";
+      allowedNetworks = [
+        "192.168.1.0/24"
+        "10.100.0.0/24"
+      ];
+    };
+    
+    # 共通のkeepalive設定
+    persistentKeepalive = 25;
+  };
 }

--- a/cells/core/darwinProfiles.nix
+++ b/cells/core/darwinProfiles.nix
@@ -100,9 +100,7 @@
       endpointPath = cfg.wireguard.darwin.endpointPath;
       interfaceName = cfg.wireguard.darwin.interfaceName;
       interfaceAddress = "${cfg.wireguard.darwin.clientIp}/32";
-      peerAllowedIPs = 
-        cfg.wireguard.darwin.allowedNetworks ++ 
-        [ "${cfg.wireguard.network.serverIp}/32" ];
+      peerAllowedIPs = cfg.wireguard.darwin.allowedNetworks ++ [ "${cfg.wireguard.network.serverIp}/32" ];
       persistentKeepalive = cfg.wireguard.persistentKeepalive;
       isDarwin = true;
     }

--- a/cells/core/darwinProfiles.nix
+++ b/cells/core/darwinProfiles.nix
@@ -91,20 +91,19 @@
     }:
     let
       sopsWireGuardHelper = import ./sops-wireguard.nix { inherit inputs cell; };
+      cfg = import ./config.nix;
     in
     sopsWireGuardHelper.mkSopsWireGuardConfig { inherit config pkgs lib; } {
       sopsFile = "${inputs.self}/secrets/wireguard.yaml";
-      privateKeyPath = "wireguard/home/macClientPrivKey";
-      publicKeyPath = "wireguard/home/publicKey";
-      endpointPath = "wireguard/home/endpoint";
-      interfaceName = "wg-home";
-      interfaceAddress = "10.100.0.2/32";
-      peerAllowedIPs = [
-        "192.168.1.0/24"
-        "10.100.0.0/24"
-        "10.100.0.1/32"
-      ];
-      persistentKeepalive = 25;
+      privateKeyPath = cfg.wireguard.darwin.privateKeyPath;
+      publicKeyPath = cfg.wireguard.darwin.publicKeyPath;
+      endpointPath = cfg.wireguard.darwin.endpointPath;
+      interfaceName = cfg.wireguard.darwin.interfaceName;
+      interfaceAddress = "${cfg.wireguard.darwin.clientIp}/32";
+      peerAllowedIPs = 
+        cfg.wireguard.darwin.allowedNetworks ++ 
+        [ "${cfg.wireguard.network.serverIp}/32" ];
+      persistentKeepalive = cfg.wireguard.persistentKeepalive;
       isDarwin = true;
     }
     // {

--- a/cells/core/nixosProfiles/security.nix
+++ b/cells/core/nixosProfiles/security.nix
@@ -8,6 +8,7 @@
 }:
 let
   sopsWireGuardHelper = import ../sops-wireguard.nix { inherit inputs cell; };
+  cfg = import ../config.nix;
 in
 {
   # PAM設定
@@ -36,13 +37,13 @@ in
   # WireGuard設定を共通モジュールから適用
   sopsWireGuardHelper.mkSopsWireGuardConfig { inherit config pkgs lib; } {
     sopsFile = "${inputs.self}/secrets/wireguard.yaml";
-    privateKeyPath = "wireguard/home/nixosClientPrivKey";
-    publicKeyPath = "wireguard/home/publicKey";
-    interfaceName = "wg0";
-    interfaceAddress = "10.100.0.4/24";
-    peerEndpoint = "192.168.1.1:13231";
-    peerAllowedIPs = [ "10.100.0.1/32" ];
-    persistentKeepalive = 25;
+    privateKeyPath = cfg.wireguard.nixos.privateKeyPath;
+    publicKeyPath = cfg.wireguard.nixos.publicKeyPath;
+    interfaceName = cfg.wireguard.nixos.interfaceName;
+    interfaceAddress = "${cfg.wireguard.nixos.clientIp}/24";
+    peerEndpoint = cfg.wireguard.nixos.serverEndpoint;
+    peerAllowedIPs = [ "${cfg.wireguard.network.serverIp}/32" ];
+    persistentKeepalive = cfg.wireguard.persistentKeepalive;
     isDarwin = false;
   }
 )


### PR DESCRIPTION
## Summary
- `cells/core/config.nix`にWireGuard設定を集約
- IPアドレス、インターフェース名、パスなどすべての設定値を外部化
- `nixosProfiles/security.nix`と`darwinProfiles.nix`を更新し、config.nixの値を使用
- ハードコードされた値を完全に削除

## 変更内容
### config.nix
- WireGuardセクションを追加
- NixOSとDarwin用の設定を分離
- 共通設定（ネットワーク、keepalive）を定義

### nixosProfiles/security.nix & darwinProfiles.nix
- config.nixから設定値を読み込むように変更
- ハードコードされたIPアドレスやパスを削除

## Test plan
- [x] `nix fmt` でコード整形
- [x] `nix flake check` で設定検証