### PR TITLE
命名規則をcamelCaseに統一

### DIFF
--- a/cells/dev/homeProfiles.nix
+++ b/cells/dev/homeProfiles.nix
@@ -4,16 +4,7 @@
   cell,
 }:
 {
-  # 分割されたモジュール
-  git = import ./homeProfiles/version-control.nix { inherit inputs cell; };
-  zsh = import ./homeProfiles/shell-tools.nix { inherit inputs cell; };
-  vim = import ./homeProfiles/editors.nix { inherit inputs cell; };
-  google_cloud_sdk = import ./homeProfiles/cloud-tools.nix { inherit inputs cell; };
-  manage_secrets = import ./homeProfiles/security-tools.nix { inherit inputs cell; };
-  cocoapods = import ./homeProfiles/development-tools.nix { inherit inputs cell; };
-  claude_code = import ./homeProfiles/ai-tools.nix { inherit inputs cell; };
-
-  # エイリアス（互換性のため）
+  # モジュール（camelCase）
   versionControl = import ./homeProfiles/version-control.nix { inherit inputs cell; };
   shellTools = import ./homeProfiles/shell-tools.nix { inherit inputs cell; };
   editors = import ./homeProfiles/editors.nix { inherit inputs cell; };
@@ -22,21 +13,4 @@
   developmentTools = import ./homeProfiles/development-tools.nix { inherit inputs cell; };
   aiTools = import ./homeProfiles/ai-tools.nix { inherit inputs cell; };
 
-  /*
-    graphql =
-    { pkgs, ... }: {
-      home.packages = with pkgs; [
-        get-graphql-schema
-      ];
-    };
-  */
-
-  /*
-    biome =
-    { pkgs, ... }: {
-      home.packages = with pkgs; [
-        biome
-      ];
-    };
-  */
 }

--- a/cells/toplevel/darwinConfigurations.nix
+++ b/cells/toplevel/darwinConfigurations.nix
@@ -25,15 +25,13 @@ in
       imports = [
         inputs.cells.core.homeProfiles.default
 
-        inputs.cells.dev.homeProfiles.git
-        inputs.cells.dev.homeProfiles.zsh
-        inputs.cells.dev.homeProfiles.vim
-        inputs.cells.dev.homeProfiles.google_cloud_sdk
-        inputs.cells.dev.homeProfiles.manage_secrets
-        inputs.cells.dev.homeProfiles.cocoapods
-        inputs.cells.dev.homeProfiles.claude_code
-        # inputs.cells.dev.homeProfiles.biome
-        # inputs.cells.dev.homeProfiles.graphql
+        inputs.cells.dev.homeProfiles.versionControl
+        inputs.cells.dev.homeProfiles.shellTools
+        inputs.cells.dev.homeProfiles.editors
+        inputs.cells.dev.homeProfiles.cloudTools
+        inputs.cells.dev.homeProfiles.securityTools
+        inputs.cells.dev.homeProfiles.developmentTools
+        inputs.cells.dev.homeProfiles.aiTools
 
         inputs.cells.shinbunbun.homeProfiles.default
       ];

--- a/cells/toplevel/nixosConfigurations.nix
+++ b/cells/toplevel/nixosConfigurations.nix
@@ -52,11 +52,11 @@ in
           inputs.cells.core.homeProfiles.default
           inputs.cells.shinbunbun.homeProfiles.default
 
-          inputs.cells.dev.homeProfiles.git
-          inputs.cells.dev.homeProfiles.zsh
-          inputs.cells.dev.homeProfiles.vim
-          inputs.cells.dev.homeProfiles.manage_secrets
-          inputs.cells.dev.homeProfiles.claude_code
+          inputs.cells.dev.homeProfiles.versionControl
+          inputs.cells.dev.homeProfiles.shellTools
+          inputs.cells.dev.homeProfiles.editors
+          inputs.cells.dev.homeProfiles.securityTools
+          inputs.cells.dev.homeProfiles.aiTools
         ];
       };
     };


### PR DESCRIPTION
## Summary
- homeProfilesの命名規則をsnake_caseからcamelCaseに統一
- コメントアウトされた未使用のプロファイル（graphql、biome）を削除
- nixosConfigurationsとdarwinConfigurationsを新しい命名に更新

## 変更内容
### homeProfiles.nix
- snake_case（`git`, `zsh`, `vim` など）をcamelCase（`versionControl`, `shellTools`, `editors` など）に変更
- 不要なコメントアウトコードを削除

### nixosConfigurations.nix & darwinConfigurations.nix
- 新しいcamelCase名を使用するよう更新

## Test plan
- [x] `nix fmt` でコード整形
- [x] `nix flake check` で設定検証