### PR TITLE
ユーザー名とSOPS設定を中央管理化

### DIFF
--- a/cells/core/config.nix
+++ b/cells/core/config.nix
@@ -1,6 +1,18 @@
 # cells/core/config.nix
 # 共通設定値を管理するファイル
 {
+  # ユーザー設定
+  users = {
+    nixos = {
+      username = "bunbun";
+      homeDirectory = "/home/bunbun";
+    };
+    darwin = {
+      username = "shinbunbun";
+      homeDirectory = "/Users/shinbunbun";
+    };
+  };
+
   # ネットワーク設定
   networking = {
     # ホスト情報
@@ -41,6 +53,11 @@
       "192.168.11.0/24"
       "163.143.0.0/16"
     ];
+  };
+
+  # SOPS設定
+  sops = {
+    keyFile = "/var/lib/sops-nix/key.txt";
   };
 
   # Kubernetes設定

--- a/cells/core/darwinProfiles.nix
+++ b/cells/core/darwinProfiles.nix
@@ -108,7 +108,7 @@
       # Darwin用のSOPS基本設定
       sops = {
         defaultSopsFile = "${inputs.self}/secrets/wireguard.yaml";
-        age.keyFile = "/var/lib/sops-nix/key.txt";
+        age.keyFile = cfg.sops.keyFile;
       };
     };
 }

--- a/cells/core/nixosProfiles/security.nix
+++ b/cells/core/nixosProfiles/security.nix
@@ -22,7 +22,7 @@ in
   # SOPS設定
   sops = {
     defaultSopsFile = "${inputs.self}/secrets/ssh-keys.yaml";
-    age.keyFile = "/var/lib/sops-nix/key.txt";
+    age.keyFile = cfg.sops.keyFile;
 
     secrets."ssh_keys/bunbun" = {
       path = "/etc/ssh/authorized_keys.d/bunbun";

--- a/cells/toplevel/darwinConfigurations.nix
+++ b/cells/toplevel/darwinConfigurations.nix
@@ -3,7 +3,8 @@
   cell,
 }:
 let
-  username = "shinbunbun";
+  cfg = import ../core/config.nix;
+  username = cfg.users.darwin.username;
 in
 {
   macOS = {
@@ -40,7 +41,7 @@ in
     users.users = {
       ${username} = {
         name = username;
-        home = "/Users/${username}";
+        home = cfg.users.darwin.homeDirectory;
         shell = inputs.nixpkgs.pkgs.zsh;
         createHome = true;
       };

--- a/cells/toplevel/nixosConfigurations.nix
+++ b/cells/toplevel/nixosConfigurations.nix
@@ -8,7 +8,8 @@
 }:
 let
   isVM = builtins.getEnv "NIXOS_BUILD_VM" == "1";
-  homeMachineUsername = "bunbun";
+  cfg = import ../core/config.nix;
+  homeMachineUsername = cfg.users.nixos.username;
 in
 {
   homeMachine = {


### PR DESCRIPTION
## Summary
- `cells/core/config.nix`にユーザー設定を集約
- NixOSとDarwin用のユーザー名とホームディレクトリを管理
- SOPS keyFileパスも中央管理化

## 変更内容
### config.nix
- ユーザー設定セクションを追加（NixOS: bunbun、Darwin: shinbunbun）
- SOPS設定セクションを追加（keyFileパス）

### 更新されたファイル
- `nixosConfigurations.nix`: config.nixからユーザー名を取得
- `darwinConfigurations.nix`: config.nixからユーザー名とホームディレクトリを取得
- `nixosProfiles/security.nix`: SOPS keyFileをconfig.nixから取得
- `darwinProfiles.nix`: SOPS keyFileをconfig.nixから取得

## メリット
- ユーザー名の変更が1箇所で可能
- 新しいマシンの追加が容易
- 設定の一貫性向上

## Test plan
- [x] `nix fmt` でコード整形
- [x] `nix flake check` で設定検証