### PR TITLE
未使用のVMファイルを削除し、.gitignoreを整理

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,7 @@ sops-nix
 .envrc
 *.swp
 *.swo
+
+# VM関連ファイル
 nixos-efi-vars.fd
 nixos.qcow2


### PR DESCRIPTION
## Summary
- 未使用のVMファイルを削除
- .gitignoreにコメントを追加してVM関連ファイルをグループ化

## 変更内容
### 削除されたファイル
- `nixos-efi-vars.fd` (528 KB)
- `nixos.qcow2` (18 MB)  
- `vm.log` (1.8 KB)

これらのファイルは既に.gitignoreに含まれており、リポジトリには追跡されていませんでした。

### .gitignore
- VM関連ファイルのエントリにコメントを追加
- 可読性を向上

## Test plan
- [x] ファイルが正常に削除されたことを確認
- [x] .gitignoreが正しく更新されたことを確認