### PR TITLE
refactor: ハードコードされた値をconfig.nixに集約

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+## 作業ルール
+- 新しい作業を始める時はmainに移動してpullしてbranchを切ってください
+- 作業が終わったら、`nix flake check`と`nix fmt`と`nix build`で動作確認を行ってください

--- a/cells/core/config.nix
+++ b/cells/core/config.nix
@@ -13,6 +13,20 @@
     };
   };
 
+  # Git設定
+  git = {
+    userName = "shinbunbun";
+    userEmail = "34409044+shinbunbun@users.noreply.github.com";
+    coreEditor = "code --wait";
+  };
+
+  # システムバージョン設定
+  system = {
+    nixosStateVersion = "21.11";
+    homeStateVersion = "24.11";
+    timeZone = "Asia/Tokyo";
+  };
+
   # ネットワーク設定
   networking = {
     # ホスト情報

--- a/cells/core/nixosProfiles/base.nix
+++ b/cells/core/nixosProfiles/base.nix
@@ -6,8 +6,11 @@
   lib,
   ...
 }:
+let
+  configValues = import ../config.nix;
+in
 {
-  system.stateVersion = "21.11";
+  system.stateVersion = configValues.system.nixosStateVersion;
   system.autoUpgrade.enable = false;
   system.autoUpgrade.allowReboot = false;
 
@@ -18,7 +21,7 @@
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
 
-  time.timeZone = "Asia/Tokyo";
+  time.timeZone = configValues.system.timeZone;
 
   users.users.bunbun = {
     isNormalUser = true;

--- a/cells/dev/homeProfiles/version-control.nix
+++ b/cells/dev/homeProfiles/version-control.nix
@@ -1,15 +1,18 @@
 # cells/dev/homeProfiles/version-control.nix
 { inputs, cell }:
 { pkgs, ... }:
+let
+  configValues = import ../../core/config.nix;
+in
 {
   programs.git = {
     enable = true;
 
-    userName = "shinbunbun";
-    userEmail = "34409044+shinbunbun@users.noreply.github.com";
+    userName = configValues.git.userName;
+    userEmail = configValues.git.userEmail;
 
     extraConfig = {
-      core.editor = "code --wait";
+      core.editor = configValues.git.coreEditor;
     };
   };
 }


### PR DESCRIPTION
## 概要
ハードコードされた値を`config.nix`に移動し、設定の一元管理を実現しました。

## 変更内容
- `system.stateVersion`を`config.nix`に移動
- Git設定（`userName`、`userEmail`、`coreEditor`）を`config.nix`に移動  
- `timeZone`設定を`config.nix`に移動
- 各モジュールは`import`文で`config.nix`を読み込むように変更

## 技術的詳細
- `cell.config`経由でのアクセスが機能しなかったため、直接`import`を使用
- `core`セルからは`import ../config.nix`
- `dev`セルからは`import ../../core/config.nix`

## テスト
- [x] `nix flake check`が成功することを確認
- [x] `nix fmt`を実行済み