### PR TITLE
refactor: コメントアウトされた不要なコードを削除

### DIFF
--- a/cells/core/homeProfiles.nix
+++ b/cells/core/homeProfiles.nix
@@ -7,7 +7,5 @@
     home.stateVersion = "24.11";
 
     xdg.enable = true;
-    # programs.gpg.enable = true;
-    # programs.ssh.enable = true;
   };
 }

--- a/cells/shinbunbun/homeProfiles.nix
+++ b/cells/shinbunbun/homeProfiles.nix
@@ -20,18 +20,6 @@
       # Let Home Manager install and manage itself.
       programs.home-manager.enable = true;
 
-      # GitHub CLI config
-      /*
-        programs.git.extraConfig = {
-          "credential \"https://github.com\"" = {
-            helper = "gh auth git-credential";
-          };
-          "credential \"https://gist.github.com\"" = {
-            helper = "gh auth git-credential";
-          };
-        };
-      */
-
       # font setting
       fonts.fontconfig.enable = true;
     };

--- a/cells/toplevel/nixosConfigurations.nix
+++ b/cells/toplevel/nixosConfigurations.nix
@@ -19,12 +19,6 @@ in
       home = inputs.home-manager;
     };
 
-    /*
-      meta = {
-        description = "Home machine NixOS configuration";
-      };
-    */
-
     imports = [
       inputs.cells.core.nixosProfiles.default
       inputs.cells.core.nixosProfiles.optimise
@@ -53,7 +47,6 @@ in
       else
         [
           ./hardwareConfigurations/homeMachine.nix
-          # inputs.cells.core.nixosProfiles.sops
         ]
     );
 
@@ -74,17 +67,4 @@ in
       };
     };
   };
-
-  # ciMachine = {
-  #   bee = {
-  #     system = "x86_64-linux";
-  #     pkgs = inputs.nixpkgs;
-  #   };
-
-  #   imports = [
-  #     ./hardwareConfigurations/homeMachine.nix
-  #     inputs.cells.core.ciNixosProfiles.ciMachine
-  #   ];
-
-  # };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -30,8 +30,6 @@
     };
 
     hive = {
-      # url = "github:divnix/hive";
-      # url = "/Users/shinbunbun/hive";
       url = "github:shinbunbun/hive?ref=shinbunbun";
       inputs.nixpkgs.follows = "nixpkgs";
     };
@@ -55,10 +53,6 @@
       flake-utils,
       ...
     }@inputs:
-    # ① growOn で各種セルを展開
-    # let
-    # customSelf = self // { renamer = cell: target: target; };
-    # base =
     let
       base =
         std.growOn
@@ -81,23 +75,6 @@
                 (functions "nixosProfiles")
                 (functions "darwinProfiles")
                 (functions "homeProfiles")
-                # (hive.blockTypes.nixosConfigurations)
-                # (darwinConfigurations // { ci.build = true; })
-                # (devshells "shells" { ci.build = true; })
-                /*
-                  (
-                    nixosConfigurations
-                    // {
-                      ci.build = true;
-                      transform =
-                        config:
-                        config
-                        // {
-                          targetDrv = config.config.system.build.toplevel;
-                        };
-                    }
-                  )
-                */
                 (
                   nixosConfigurations
                   // {
@@ -110,21 +87,6 @@
               ];
           }
           {
-            # nixosConfigurations = hive.collect.__functor customSelf customSelf "nixosConfigurations";
-            /*
-              nixosConfigurations =
-              let
-                collected = hive.collect self "nixosConfigurations";
-              in
-              builtins.mapAttrs (
-                name: config:
-                config
-                // {
-                  # targetDrv = builtins.trace "nixosConfigurations: ${builtins.typeOf (config.config.system.build.toplevel)}" config.config.system.build.toplevel;
-                  targetDrv = config.config.system.build.toplevel;
-                }
-              ) collected;
-            */
             nixosConfigurations = hive.collect self "nixosConfigurations";
             darwinConfigurations = hive.collect self "darwinConfigurations";
             devShells = hive.harvest self [


### PR DESCRIPTION
## 概要
コードベース全体からコメントアウトされた不要なコードを削除し、クリーンアップしました。

## 削除内容

### flake.nix
- 古いhive URLオプション（元のリポジトリとローカルパス）
- 未使用の`customSelf`定義
- 古い`nixosConfigurations`の実装方法
- デバッグ用のトレース出力

### cells/core/homeProfiles.nix
- 未使用のGPG設定（`programs.gpg.enable`）
- 未使用のSSH設定（`programs.ssh.enable`）

### cells/toplevel/nixosConfigurations.nix
- homeMachineのmeta情報（現在使用されていない）
- sopsプロファイルのコメントアウト
- ciMachine設定全体（CI環境の設定）

### cells/shinbunbun/homeProfiles.nix
- GitHub認証ヘルパーの設定（git credential helper）

## 理由
- 使用されていないコードがコメントとして残っていると、メンテナンス時に混乱を招く
- 必要になった場合はGitの履歴から復元可能
- コードベースをクリーンに保つことで可読性が向上

## テスト
- [x] `nix flake check`が成功することを確認
- [x] `nix fmt`を実行済み

## 注意事項
- 有用なドキュメントコメント（例：参考URL）は削除していません
- ciMachine設定は将来CI環境を構築する場合に必要になる可能性がありますが、その際はGit履歴から復元できます