### PR TITLE
refactor: 属性名をcamelCaseに統一

### DIFF
--- a/cells/dev/homeProfiles/cloud-tools.nix
+++ b/cells/dev/homeProfiles/cloud-tools.nix
@@ -2,12 +2,12 @@
 { inputs, cell }:
 { pkgs, ... }:
 let
-  google-cloud-sdk-with-cloud-datastore-emulator = pkgs.google-cloud-sdk.withExtraComponents ([
+  googleCloudSdkWithCloudDatastoreEmulator = pkgs.google-cloud-sdk.withExtraComponents ([
     pkgs.google-cloud-sdk.components.cloud-datastore-emulator
   ]);
 in
 {
   home.packages = with pkgs; [
-    google-cloud-sdk-with-cloud-datastore-emulator
+    googleCloudSdkWithCloudDatastoreEmulator
   ];
 }


### PR DESCRIPTION
## 概要
Nix属性名の命名規則をcamelCaseに統一しました。

## 変更内容
### cloud-tools.nix
- `google-cloud-sdk-with-cloud-datastore-emulator` → `googleCloudSdkWithCloudDatastoreEmulator`

## 変更しなかった項目
### ファイル名
- std/hiveの規約に従い、cells内のファイル名（nixosConfigurations.nix等）はcamelCaseを維持
- これはstd/hiveがcellBlocksのファイル名をcamelCaseで期待するため

### 属性名
- **SOPS secrets**: snake_case を維持
  - 例：`couchdb_admin_password`、`ssh_keys/bunbun`
  - 理由：SOPSファイル内のキー名と一致させる慣習
  
- **システムサービス名**: 元の形式を維持
  - 例：`sudo_local`
  - 理由：macOSのシステムサービス名
  
- **ツール固有の設定**: 元の形式を維持
  - 例：starshipの`time_format`、`utc_time_offset`
  - 理由：各ツールの設定フォーマットに準拠

## テスト
- [x] `nix flake check`が成功することを確認
- [x] `nix fmt`を実行済み

## 結果
最小限の変更で、Nixコードの慣習に従った一貫性のある命名規則を実現しました。