### PR TITLE
refactor: with pkgs; の使用を削減し、明示的なインポートに変更

### DIFF
--- a/cells/core/nixosProfiles/base.nix
+++ b/cells/core/nixosProfiles/base.nix
@@ -48,9 +48,9 @@ in
 
   programs.zsh.enable = true;
 
-  environment.systemPackages = with pkgs; [
-    vim
-    wget
+  environment.systemPackages = [
+    pkgs.vim
+    pkgs.wget
   ];
 
   virtualisation = {

--- a/cells/core/nixosProfiles/kubernetes.nix
+++ b/cells/core/nixosProfiles/kubernetes.nix
@@ -21,10 +21,10 @@ let
 in
 {
   # Kubernetes tools
-  environment.systemPackages = with pkgs; [
-    kompose
-    kubectl
-    kubernetes
+  environment.systemPackages = [
+    pkgs.kompose
+    pkgs.kubectl
+    pkgs.kubernetes
   ];
 
   # Kubernetes API port

--- a/cells/core/nixosProfiles/system-tools.nix
+++ b/cells/core/nixosProfiles/system-tools.nix
@@ -20,8 +20,8 @@
   ...
 }:
 {
-  environment.systemPackages = with pkgs; [
-    polkit
-    wireguard-tools
+  environment.systemPackages = [
+    pkgs.polkit
+    pkgs.wireguard-tools
   ];
 }

--- a/cells/dev/homeProfiles/ai-tools.nix
+++ b/cells/dev/homeProfiles/ai-tools.nix
@@ -11,8 +11,8 @@
 { inputs, cell }:
 { pkgs, ... }:
 {
-  home.packages = with pkgs; [
-    claude-code
+  home.packages = [
+    pkgs.claude-code
   ];
 
   home.file.".claude/CLAUDE.md" = {

--- a/cells/dev/homeProfiles/cloud-tools.nix
+++ b/cells/dev/homeProfiles/cloud-tools.nix
@@ -16,7 +16,7 @@ let
   ]);
 in
 {
-  home.packages = with pkgs; [
+  home.packages = [
     googleCloudSdkWithCloudDatastoreEmulator
   ];
 }

--- a/cells/dev/homeProfiles/development-tools.nix
+++ b/cells/dev/homeProfiles/development-tools.nix
@@ -10,7 +10,7 @@
 { inputs, cell }:
 { pkgs, ... }:
 {
-  home.packages = with pkgs; [
-    cocoapods
+  home.packages = [
+    pkgs.cocoapods
   ];
 }

--- a/cells/dev/homeProfiles/security-tools.nix
+++ b/cells/dev/homeProfiles/security-tools.nix
@@ -11,8 +11,8 @@
 { inputs, cell }:
 { pkgs, ... }:
 {
-  home.packages = with pkgs; [
-    age
-    sops
+  home.packages = [
+    pkgs.age
+    pkgs.sops
   ];
 }

--- a/cells/shinbunbun/homeProfiles.nix
+++ b/cells/shinbunbun/homeProfiles.nix
@@ -6,15 +6,15 @@
   default =
     { pkgs, ... }:
     {
-      home.packages = with pkgs; [
-        gh
-        llvm
-        nerd-fonts.fira-code
-        nil
-        nixd
-        nixfmt-rfc-style
-        warp-terminal
-        google-chrome
+      home.packages = [
+        pkgs.gh
+        pkgs.llvm
+        pkgs.nerd-fonts.fira-code
+        pkgs.nil
+        pkgs.nixd
+        pkgs.nixfmt-rfc-style
+        pkgs.warp-terminal
+        pkgs.google-chrome
       ];
 
       # Let Home Manager install and manage itself.


### PR DESCRIPTION
## 概要
`with pkgs;` の使用を削減し、明示的なパッケージ参照に変更しました。

## 変更内容
以下の8つのファイルで `with pkgs;` を `pkgs.` プレフィックスに変更：

### NixOSプロファイル
- `cells/core/nixosProfiles/system-tools.nix`
- `cells/core/nixosProfiles/base.nix`
- `cells/core/nixosProfiles/kubernetes.nix`

### home-managerプロファイル
- `cells/dev/homeProfiles/ai-tools.nix`
- `cells/dev/homeProfiles/cloud-tools.nix`
- `cells/dev/homeProfiles/development-tools.nix`
- `cells/dev/homeProfiles/security-tools.nix`
- `cells/shinbunbun/homeProfiles.nix`

## 変更例
```nix
# Before
home.packages = with pkgs; [
  vim
  wget
];

# After
home.packages = [
  pkgs.vim
  pkgs.wget
];
```

## 効果
- パッケージの依存関係が明確になりました
- 名前の衝突リスクが削減されました
- コードの可読性が向上しました
- どのパッケージがpkgsから来ているかが一目で分かるようになりました

## テスト
- `nix flake check`: ✅ 成功
- `nix fmt`: ✅ フォーマット済み