### PR TITLE
feat: Cloudflare Tunnel経由でのGrafana公開設定

### DIFF
--- a/secrets/monitoring.yaml
+++ b/secrets/monitoring.yaml
@@ -1,0 +1,28 @@
+cloudflare:
+    account_tag: ENC[AES256_GCM,data:NreSPD90sqRE0fsm+PxwB22NNBOHXTCa6ReDaurVDFU=,iv:9Ssenbas3VmG2lnDVEc3/dM38/4eYVJWgpibr+5+hps=,tag:PfYOmyB+KTU09gStZm6+pA==,type:str]
+    tunnel_secret: ENC[AES256_GCM,data:WmXjVAQx435Y9IMSl6i4tyIiZs79CSYK/B2EqSAFqbaOcJVQjQG2MYAs2Bs=,iv:ulVJRS9LTdGHvU4/ViwQIpiH6g/AAx/ZruyfzJetmus=,tag:a7yHGqZLRATAQvPU/g2UZQ==,type:str]
+    tunnel_id: ENC[AES256_GCM,data:a9OHiOh9JxXZi6YSP1iQTl89Ad4YLnloIDCrVWCXqDW5ovoM,iv:fPld7tUz3YDwX9GKCVVV1E/VF0fU4Sh2i8oQDDByGFA=,tag:OxPDi3zLHofomokGEPojzg==,type:str]
+sops:
+    age:
+        - recipient: age1p057v4es63p6fef8usy67tkza7dj4xg326w5gm3c7rdthcd3xqlqps38z9
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBdzJGVzBJcFIxbTlNa3Ju
+            bGtGMXJHSjd4THBpNnZNdnZDRGJMei9ZODNzCmRiM0pvT3hQbkpKRXczcVdyQzB5
+            NTFVWnlKNHg0RXEvTHpSbEd0YVRVV00KLS0tIDRGdW5XWkRuVmZTZWloUGFzRi8z
+            b29YUTJxZUdreG9NeEtjNTBpc2dhakkKkU2HJ64/us6reGvXfO36dBgrniisV+3j
+            FE728p2u0OLw9dQb/ZnMwiLqo7By+kyY1J4AKWqK52vLOuTW1QVIIg==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1tuyn9u7qca3mpk082a94mnwpwgue7wlux2c7mruyxg7fz9y45qrqnqw3yx
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB5cnluKzBkWjYzL2lRTWlk
+            Wk1aSU83c05uam9JYWlCbzBId1RxYkM1eWcwCjRkcklpMjIwZVN6Q3U3MHJ2MlUv
+            c2RWcjBkNWM0bDhQNjhpNTA4OU9nVkkKLS0tIEhQMEUvaEpXekEreVVIZ00xYWxH
+            TUM1K1E0a2oyQm9xaXRockFrRlpCZXMKGYBHF81w7xrqcjA0PfIGtS1XZBK1+MCL
+            WTlF15HuRRk158XaKGT8UcR3lgAw0AG7RgOYb3JYuwUM9TGkkWKAXA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2025-07-26T14:58:09Z"
+    mac: ENC[AES256_GCM,data:nKa8Gmcp/IDKYQnHsxXrEYkwGhXl/PxpjcG5w+qDWmYnKH8SUeF6dCMPaBfNEq+xxHFu/nGkXtl3pYWp/q8MoZ6MMJdkLNyrazh3X4hmaHViI6/lu7sAELzcrR7ZqaRHJMahN45WMjItxny72tgRBqYdi9XJUnmyHjNkoaVw7do=,iv:5DWOAkEqBxShUQBoAzkSyMhmBcmtSuRZBIKbCAPCJVg=,tag:iIjUTERFww9eawQp0qVeBg==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.10.2


### PR DESCRIPTION
## 概要
Phase 1の最終ステップとして、GrafanaをCloudflare Tunnel経由で外部公開する設定を追加しました。

## 変更内容

### Cloudflare Tunnelの設定
- `cloudflared tunnel create monitoring`で新しいトンネルを作成
- 認証情報をSOPSで暗号化（secrets/monitoring.yaml）
- DNSレコード（CNAME）を自動設定

### monitoring.nixの更新
- Cloudflare Tunnel用のSOPS secrets設定を追加
- credentials.jsonテンプレートの自動生成
- services.cloudflared.tunnelsに「monitoring」トンネルを追加

## 動作確認
- [x] `nix flake check` が成功
- [x] `nix fmt` でフォーマット済み
- [x] `nixos-rebuild` でビルド成功
- [x] cloudflared-tunnel-monitoringサービスが正常起動

## Phase 1完了
これでPhase 1（基本監視システム構築）が完了しました：
- ✅ Prometheus & Node Exporter
- ✅ Grafana & ダッシュボード
- ✅ Cloudflare Tunnel経由での外部公開

関連Issue: #81
関連PR: #91, #92