### PR TITLE
feat: 監視システムPhase 3 - AlertmanagerとDiscord通知の実装

### DIFF
--- a/cells/core/nixosProfiles.nix
+++ b/cells/core/nixosProfiles.nix
@@ -29,6 +29,7 @@
   systemTools = import ./nixosProfiles/system-tools.nix { inherit inputs cell; };
   wireguard = import ./nixosProfiles/wireguard.nix { inherit inputs cell; };
   monitoring = import ./nixosProfiles/monitoring.nix { inherit inputs cell; };
+  alertmanager = import ./nixosProfiles/alertmanager.nix { inherit inputs cell; };
 
   # 既存のモジュール
   obsidian-livesync = import ./nixosProfiles/obsidian-livesync.nix { inherit inputs cell; };

--- a/cells/core/nixosProfiles/alertmanager.nix
+++ b/cells/core/nixosProfiles/alertmanager.nix
@@ -1,0 +1,271 @@
+# cells/core/nixosProfiles/alertmanager.nix
+/*
+  Alertmanager設定モジュール
+
+  このモジュールはPrometheusのアラート管理と
+  Discord通知を設定します：
+  - Alertmanager: アラートのルーティングと通知
+  - Discord Webhook: アラート通知の送信先
+  - アラートルール: 監視対象の異常を検知
+
+  アラートはグループ化され、重複排除された後
+  Discordチャンネルに送信されます。
+*/
+{ inputs, cell }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  # config.nixから設定を読み込み
+  cfg = import ../config.nix;
+in
+{
+  # Alertmanager設定
+  services.prometheus.alertmanager = {
+    enable = true;
+    port = cfg.monitoring.alertmanager.port;
+    checkConfig = false;  # 環境変数を使うため、ビルド時検証を無効化
+    
+    # configTextではなくconfigurationを使い、環境変数を使用
+    configuration = {
+      global = {
+        resolve_timeout = "5m";
+      };
+
+      route = {
+        receiver = "discord";
+        group_by = [ "alertname" "cluster" "service" ];
+        group_wait = "10s";
+        group_interval = "10s";
+        repeat_interval = "1h";
+        routes = [
+          {
+            match = { severity = "critical"; };
+            receiver = "discord";
+            repeat_interval = "15m";
+          }
+          {
+            match = { severity = "warning"; };
+            receiver = "discord";
+            repeat_interval = "30m";
+          }
+        ];
+      };
+
+      receivers = [
+        {
+          name = "discord";
+          discord_configs = [
+            {
+              webhook_url = "$DISCORD_WEBHOOK_URL";
+              send_resolved = true;
+              
+              # メンション付きメッセージ
+              message = ''{{ if eq .Status "firing" }}<@$DISCORD_USER_ID> {{ end }}'';
+            }
+          ];
+        }
+      ];
+
+      inhibit_rules = [
+        {
+          source_match = { severity = "critical"; };
+          target_match = { severity = "warning"; };
+          equal = [ "alertname" "instance" ];
+        }
+      ];
+    };
+    
+    # 環境変数ファイルを指定
+    environmentFile = "/run/secrets/rendered/alertmanager/env";
+  };
+
+  # Prometheus側のAlertmanager連携設定
+  services.prometheus.alertmanagers = [
+    {
+      static_configs = [
+        {
+          targets = [ "localhost:${toString cfg.monitoring.alertmanager.port}" ];
+        }
+      ];
+    }
+  ];
+
+  # アラートルールの設定
+  services.prometheus.rules = [
+    (builtins.toJSON {
+      groups = [
+        {
+          name = "system";
+          interval = "30s";
+          rules = [
+            # インスタンスダウン
+            {
+              alert = "InstanceDown";
+              expr = "up == 0";
+              for = "2m";
+              labels = {
+                severity = "critical";
+              };
+              annotations = {
+                summary = "Instance {{ $labels.instance }} down";
+                description = "{{ $labels.instance }} of job {{ $labels.job }} has been down for more than 2 minutes.";
+              };
+            }
+            # 高CPU使用率
+            {
+              alert = "HighCPUUsage";
+              expr = "(1 - avg(rate(node_cpu_seconds_total{mode=\"idle\"}[5m])) by (instance)) * 100 > 80";
+              for = "5m";
+              labels = {
+                severity = "warning";
+              };
+              annotations = {
+                summary = "High CPU usage on {{ $labels.instance }}";
+                description = "CPU usage is above 80% (current value: {{ $value }}%)";
+              };
+            }
+            # 高メモリ使用率
+            {
+              alert = "HighMemoryUsage";
+              expr = "(1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)) * 100 > 85";
+              for = "5m";
+              labels = {
+                severity = "warning";
+              };
+              annotations = {
+                summary = "High memory usage on {{ $labels.instance }}";
+                description = "Memory usage is above 85% (current value: {{ $value }}%)";
+              };
+            }
+            # ディスク容量不足
+            {
+              alert = "DiskSpaceLow";
+              expr = "(node_filesystem_size_bytes{fstype!~\"tmpfs|fuse.lxcfs\"} - node_filesystem_free_bytes{fstype!~\"tmpfs|fuse.lxcfs\"}) / node_filesystem_size_bytes{fstype!~\"tmpfs|fuse.lxcfs\"} * 100 > 85";
+              for = "5m";
+              labels = {
+                severity = "warning";
+              };
+              annotations = {
+                summary = "Low disk space on {{ $labels.instance }}";
+                description = "Disk usage is above 85% on {{ $labels.mountpoint }} (current value: {{ $value }}%)";
+              };
+            }
+            # RouterOS高温度
+            {
+              alert = "RouterOSHighTemperature";
+              expr = "mtxrHlTemperature / 10 > 60";
+              for = "5m";
+              labels = {
+                severity = "warning";
+              };
+              annotations = {
+                summary = "High temperature on RouterOS";
+                description = "RouterOS temperature is above 60°C (current value: {{ $value }}°C)";
+              };
+            }
+            # RouterOS CPU高使用率
+            {
+              alert = "RouterOSHighCPU";
+              expr = "avg(hrProcessorLoad) > 80";
+              for = "5m";
+              labels = {
+                severity = "warning";
+              };
+              annotations = {
+                summary = "High CPU usage on RouterOS";
+                description = "RouterOS CPU usage is above 80% (current value: {{ $value }}%)";
+              };
+            }
+          ];
+        }
+      ];
+    })
+  ];
+
+  # SOPS secrets設定
+  sops = {
+    # Discord Webhook URLの秘密鍵
+    secrets."alertmanager/discord_webhook_url" = {
+      key = "discord/webhook_url";
+      sopsFile = "${inputs.self}/secrets/alertmanager.yaml";
+      owner = "prometheus";
+      group = "prometheus";
+      mode = "0400";
+    };
+    
+    # Discord ユーザーIDの秘密鍵
+    secrets."alertmanager/discord_user_id" = {
+      key = "discord/user_id";
+      sopsFile = "${inputs.self}/secrets/alertmanager.yaml";
+      owner = "prometheus";
+      group = "prometheus";
+      mode = "0400";
+    };
+
+    # 環境変数テンプレート
+    templates."alertmanager/env" = {
+      content = ''
+        DISCORD_WEBHOOK_URL=${config.sops.placeholder."alertmanager/discord_webhook_url"}
+        DISCORD_USER_ID=${config.sops.placeholder."alertmanager/discord_user_id"}
+      '';
+      path = "/run/secrets/rendered/alertmanager/env";
+      owner = "prometheus";
+      group = "prometheus";
+      mode = "0400";
+    };
+    
+    # Alertmanager設定テンプレート（今は使わないがあとで使うかもしれないので残す）
+    templates."alertmanager/config.yml" = {
+      content = ''
+        global:
+          resolve_timeout: 5m
+
+        route:
+          receiver: discord
+          group_by: ['alertname', 'cluster', 'service']
+          group_wait: 10s
+          group_interval: 10s
+          repeat_interval: 1h
+          routes:
+          - match:
+              severity: critical
+            receiver: discord
+            repeat_interval: 15m
+          - match:
+              severity: warning
+            receiver: discord
+            repeat_interval: 30m
+
+        receivers:
+        - name: discord
+          discord_configs:
+          - webhook_url: ${config.sops.placeholder."alertmanager/discord_webhook_url"}
+            send_resolved: true
+
+        inhibit_rules:
+        - source_match:
+            severity: critical
+          target_match:
+            severity: warning
+          equal: ['alertname', 'instance']
+      '';
+      path = "/run/secrets/rendered/alertmanager/config.yml";
+      owner = "prometheus";
+      group = "prometheus";
+      mode = "0400";
+    };
+  };
+
+  # ファイアウォール設定（内部アクセスのみ）
+  networking.firewall.allowedTCPPorts = [ cfg.monitoring.alertmanager.port ];
+
+  # systemdサービスの依存関係
+  systemd.services.alertmanager = {
+    after = [ "prometheus.service" ];
+    wants = [ "prometheus.service" ];
+  };
+}

--- a/cells/toplevel/nixosConfigurations.nix
+++ b/cells/toplevel/nixosConfigurations.nix
@@ -25,6 +25,7 @@ in
       inputs.cells.core.nixosProfiles.obsidian-livesync
       inputs.cells.core.nixosProfiles.routeros-backup
       inputs.cells.core.nixosProfiles.monitoring
+      inputs.cells.core.nixosProfiles.alertmanager
 
       inputs.home-manager.nixosModules.home-manager
       inputs.sops-nix.nixosModules.sops

--- a/docs/alertmanager-setup.md
+++ b/docs/alertmanager-setup.md
@@ -1,0 +1,89 @@
+# Alertmanager設定手順
+
+## 概要
+PrometheusのアラートをDiscordに通知するためのAlertmanager設定手順です。
+
+## 前提条件
+- Prometheus、Grafanaが設定済み
+- Discord Webhookが作成済み
+
+## 設定手順
+
+### 1. Discord Webhook URLの設定
+
+1. Discord Webhookを作成（Discordサーバー設定から作成）
+2. `secrets/alertmanager.yaml`にWebhook URLを設定：
+   ```yaml
+   discord:
+       webhook_url: "https://discord.com/api/webhooks/YOUR_WEBHOOK_ID/YOUR_WEBHOOK_TOKEN"
+   ```
+
+3. SOPSで暗号化：
+   ```bash
+   sops -e -i secrets/alertmanager.yaml
+   ```
+
+### 2. NixOS設定の適用
+
+```bash
+sudo nixos-rebuild switch --flake .#homeMachine
+```
+
+### 3. 動作確認
+
+1. Alertmanagerのステータス確認：
+   ```bash
+   systemctl status alertmanager
+   ```
+
+2. Prometheusのアラート確認：
+   ```bash
+   curl http://localhost:9090/api/v1/alerts
+   ```
+
+3. Alertmanagerのアラート確認：
+   ```bash
+   curl http://localhost:9093/api/v1/alerts
+   ```
+
+## アラートルール
+
+以下のアラートが設定されています：
+
+- **InstanceDown**: インスタンスが2分以上ダウン（critical）
+- **HighCPUUsage**: CPU使用率が80%以上（warning）
+- **HighMemoryUsage**: メモリ使用率が85%以上（warning）
+- **DiskSpaceLow**: ディスク使用率が85%以上（warning）
+- **RouterOSHighTemperature**: RouterOSの温度が60°C以上（warning）
+- **RouterOSHighCPU**: RouterOSのCPU使用率が80%以上（warning）
+
+## トラブルシューティング
+
+### アラートが送信されない場合
+
+1. Alertmanagerのログを確認：
+   ```bash
+   journalctl -u alertmanager -f
+   ```
+
+2. Discord Webhook URLが正しいか確認
+3. SOPSの復号化が正しく行われているか確認
+
+### テストアラートの送信
+
+```bash
+curl -XPOST http://localhost:9093/api/v1/alerts -H "Content-Type: application/json" -d '[
+  {
+    "status": "firing",
+    "labels": {
+      "alertname": "TestAlert",
+      "severity": "warning",
+      "instance": "test"
+    },
+    "annotations": {
+      "summary": "This is a test alert",
+      "description": "Testing Discord webhook integration"
+    }
+  }
+]'
+```

--- a/secrets/alertmanager.yaml
+++ b/secrets/alertmanager.yaml
@@ -1,0 +1,27 @@
+discord:
+    webhook_url: ENC[AES256_GCM,data:+ZOS75zelJrthZCfJWmfGt29xgW2ls3CpsCGFcG3V2h3rcbtFl3htIeBxyQJnZrKVEkQl5wrXam4DbcdGKRDS3tV4aUKhhvyhSgnGY3i4wmWHpnpgpV5mfIbMNYXP01/apcrePnxbSbUSCFuiSqSGrkUUZUkfNuYvQ==,iv:+JWQgq5vbsM2itYoiFSM79UxTCHYNazeUSFztM09TG0=,tag:mYzcszpdKHgq+Qn/ItVCiw==,type:str]
+    user_id: ENC[AES256_GCM,data:sO2e/K7H5w/OrMJpSC68Dmkg,iv:+UgQPdcGJAtw6vaaBAzQ+LnFTfJw7/fSSHW3vB6ukGI=,tag:1jv0ldD2wh11nbBRKi+Lug==,type:str]
+sops:
+    age:
+        - recipient: age1p057v4es63p6fef8usy67tkza7dj4xg326w5gm3c7rdthcd3xqlqps38z9
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6Y0Jic0E1UWd5ZGZ6ZkNH
+            Nlh6LzZ2QStnaEM3QzVTMG9IS2hWbjJGSlQwCk54TE03RTNEZjBRSlVtN2ZOakVX
+            SlJYbWFtUFM1VFQrcmVBd202VnpzQTQKLS0tIGtIVWVNNHRBY2xtYVNTQTlKc3pt
+            K0NSZjZvSExCb0piWDVVcGt3ekNPbzgKIMdnm1kSuRhVJkB9ZVRNlDS2U51lPbr3
+            JqF9gLkaQ7EM8Dt2UPVBwJ2Nka154iHm5wXjJbGqe1LGe7XfwNuYdg==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1tuyn9u7qca3mpk082a94mnwpwgue7wlux2c7mruyxg7fz9y45qrqnqw3yx
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHUnVUeTNUVDdxVG03VXVx
+            M3BQZTk2bjZ2bWVIU0FrdlZpSFVxY1ZTdFFjCnQ5Vkc1dzFuekpoQm82cHFFSFpW
+            RkdnZ1k1S1lHbHZ1QVpkdE1DMmh2ZUEKLS0tIHRIZVdYYXBWelZBV2NQbTBIaVly
+            RTU1KzVnUmJ0YzlVdzlSODdNNExvelUKPoUj4BLYACqOaJVZbQdYKp0sWVYkJ73U
+            wJ6oz5gEZbyZJPDh5h9zU9ng8YG8IAj8GMVFJiwmnvmvtZVR11caoA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2025-07-27T05:47:55Z"
+    mac: ENC[AES256_GCM,data:sehcsHNqizf/iNlJrcbNPH4rp4sY/5arb4ySwUK6mPCXm7Woqi7a1Cva4LyorCqrHWGxyLmKj9ZqetjNs0Kb7W4fA3lpQMMMMy45ox+alvyyAzskDg+hz0zSx3wSZHTdShxqiwdbVUPW3C7sk0p/bG4OaxnlG8Fv/SJyWpA4W9E=,iv:5Bh4f3nWeWF6rl7kSiTZvlvaqiokTdO2EiBoHiD+Q0w=,tag:8phwxN3fSek19Jvc9u31bQ==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.10.2


### PR DESCRIPTION
## 概要
監視システムのPhase 3実装を完了しました。PrometheusアラートをDiscordに通知するAlertmanagerを設定しました。

## 実装内容

### Alertmanager設定
- AlertmanagerのNixOSモジュールを作成
- Discord Webhook統合（v0.25.0以降のネイティブサポート使用）
- アラートのグループ化と重複排除設定

### セキュリティ
- Discord Webhook URLをSOPSで暗号化管理
- ユーザーIDもSOPSで管理
- 環境変数経由での安全な設定展開

### アラートルール
1. **システム監視**
   - InstanceDown: インスタンスダウン検知（2分以上）
   - HighCPUUsage: CPU使用率80%以上（5分継続）
   - HighMemoryUsage: メモリ使用率85%以上（5分継続）
   - DiskSpaceLow: ディスク使用率85%以上（5分継続）

2. **RouterOS監視**
   - RouterOSHighTemperature: 温度60°C以上（5分継続）
   - RouterOSHighCPU: CPU使用率80%以上（5分継続）

### Discord通知機能
- アラート発生時にユーザーメンション付きで通知
- 重要度（critical/warning）に応じた通知間隔設定
- アラート解決時の通知も対応

## テスト結果
- [x] Alertmanagerサービスの起動確認
- [x] テストアラートの送信成功
- [x] Discord通知の受信確認
- [x] メンション機能の動作確認

## 関連ドキュメント
- `docs/alertmanager-setup.md`: 設定手順とトラブルシューティング

## 次のステップ
監視システムの3フェーズすべてが完了しました：
- Phase 1: Prometheus + Grafana ✅
- Phase 2: RouterOS SNMP監視 ✅
- Phase 3: Alertmanager + Discord通知 ✅