### PR TITLE
fix: Discord通知からメンション機能を削除

### DIFF
--- a/cells/core/nixosProfiles/alertmanager.nix
+++ b/cells/core/nixosProfiles/alertmanager.nix
@@ -70,9 +70,6 @@ in
             {
               webhook_url = "$DISCORD_WEBHOOK_URL";
               send_resolved = true;
-
-              # メンション付きメッセージ
-              message = ''{{ if eq .Status "firing" }}<@$DISCORD_USER_ID> {{ end }}'';
             }
           ];
         }


### PR DESCRIPTION
前回のテストでメンション通知が機能しないことが判明したため、
message fieldのオーバーライドを削除しました。