### PR TITLE
fix: DiskUsageRapidIncreaseアラートを削除

### DIFF
--- a/cells/core/nixosProfiles/alertmanager.nix
+++ b/cells/core/nixosProfiles/alertmanager.nix
@@ -494,19 +494,6 @@ in
                 description = "RouterOS backup timer has not triggered for {{ $value | humanizeDuration }}.";
               };
             }
-            # ディスク使用量の急激な増加
-            {
-              alert = "DiskUsageRapidIncrease";
-              expr = "delta(node_filesystem_size_bytes{mountpoint=\"/\"}[1h]) - delta(node_filesystem_free_bytes{mountpoint=\"/\"}[1h]) > 104857600";
-              for = "10m";
-              labels = {
-                severity = "warning";
-              };
-              annotations = {
-                summary = "Rapid disk usage increase detected";
-                description = "Disk usage on {{ $labels.mountpoint }} is increasing rapidly ({{ $value | humanize }}B in the last hour). This may be due to excessive logging.";
-              };
-            }
           ];
         }
         # RouterOS専用グループ

--- a/docs/monitoring-alerts-summary.md
+++ b/docs/monitoring-alerts-summary.md
@@ -107,12 +107,6 @@
   - 継続時間: 1時間
   - 重要度: warning
 
-#### ログ監視（新規追加）
-- **DiskUsageRapidIncrease**: ディスク使用量の急激な増加
-  - 条件: 1時間で100MB以上の増加
-  - 継続時間: 10分
-  - 重要度: warning
-
 ### 2. RouterOS監視 (routeros)
 
 #### システム監視


### PR DESCRIPTION
## Summary
誤検知が多いDiskUsageRapidIncreaseアラートを削除しました。

## 理由
- **誤検知が多い**: NixOSのシステムアップデートなど正常な操作でも発火
- **閾値が低すぎる**: 100MB/時間は現代のシステムでは小さすぎる
- **ノイズになりやすい**: 本当に重要な問題を見逃す原因になる

## 代替案
既存の`DiskSpaceLow`アラート（85%警告）で十分な監視が可能です。

## 変更内容
- `alertmanager.nix`からアラート定義を削除
- `monitoring-alerts-summary.md`からドキュメントを削除

## Test plan
- [x] `nix flake check`でビルドエラーがないことを確認
- [x] `nix fmt`でコードフォーマットを実行