### PR TITLE
feat: nixos-desktopにCockpitとttydを導入

### DIFF
--- a/secrets/cloudflare.yaml
+++ b/secrets/cloudflare.yaml
@@ -2,6 +2,9 @@ cloudflare:
     account-tag: ENC[AES256_GCM,data:VaYTr2wmNlGk7cm4LPvOcP8pR7BhjWkW038AYeFSva4=,iv:KcDK9R+FNR0+SBLWuQ0ILgL6KgHlUxHMmRH3mLA6ZBM=,tag:CbAIwfBiqnGHaBEUcW+Djg==,type:str]
     tunnel-id: ENC[AES256_GCM,data:fodpIc5uV4O9F4zYivOiNRxoWxMV9ccBdLk9NP8VaUXiQdXg,iv:RbtYGaBuqe0CAHq6W1rxKktQ3OxvhS116HAvGL/WSSs=,tag:5FpZ0U+sV1lwd1iDXW+quA==,type:str]
     tunnel-secret: ENC[AES256_GCM,data:MeApmKKIS1blTHqxDr0jlDOfBQLicQRgZweRUQsXYFVtGnG3kigsg7RpgGw=,iv:gaBts5AhyRc/54BGX2Ddet+kkUxqHy9Vh60eZAN+wk8=,tag:bYGKRQn35goExgvJpkPBfA==,type:str]
+    desktop-account-tag: ENC[AES256_GCM,data:gU68T9rc47whv56uq9WvudG4GvVcua46wAUcg7VROnA=,iv:yzwFWxBuK+oUdCJgh11t/DaLFbYk1k5mv6m7baH1wvs=,tag:tpmW8LV2DapY+rD4GO7/Sg==,type:str]
+    desktop-tunnel-id: ENC[AES256_GCM,data:vYj7bGCdkyMLOVLNhnXnIQCMglAaQ2XUBEmLQlap9TdGssRU,iv:4gGVA0jYr24vvE2DU8nNZcJDvdGqAaKYS2MCUuv9HdA=,tag:u3axHABPettbGzg1huEGfQ==,type:str]
+    desktop-tunnel-secret: ENC[AES256_GCM,data:rgJ4MgG1yzkUWnhIw1rBL5LXaq/aPovsk330ykR/BHiVLU00ypCAFAjZ48U=,iv:qxgGleSw3NRyaNqGiSHBBGn9XjSN9UxBPoJkqDZOiRw=,tag:vAgFZ56HAU8UUlJZ97md0Q==,type:str]
 sops:
     age:
         - recipient: age1p057v4es63p6fef8usy67tkza7dj4xg326w5gm3c7rdthcd3xqlqps38z9
@@ -31,7 +34,7 @@ sops:
             Q1ZCMlc4bUFQMFRBQm5tczlIQ3VoNzQKuHOD/UrDW0USM8uD46SS5LrCyqeilaqK
             462UNZmXihCrTLOLlwEs4nOQtQZkN12DOgUxFjpZJVXVka28iI6bvA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-08-08T07:29:50Z"
-    mac: ENC[AES256_GCM,data:ItsxvzB0DvZdcGIKKvO3e8REVuGlFEaXIbI3dxo4gsB6orolqPwMe8PlVhBh9sd7HqbXBr5SYS/EQp7tzKEERlcAdciZvHcmnl9J5HZDkui/CpGm6/eiyK/Fkbi/54kAv4/WCrHX5hpgQlPHS8/ipgepoOy82hYQnCRN1fvpguc=,iv:g7hmmlMuAjTWGvw9Gs20jISBJBAk0L3xWIn2LRRDDsw=,tag:IfXia/ELCuv4nKBP3Yh9TA==,type:str]
+    lastmodified: "2025-08-13T17:36:38Z"
+    mac: ENC[AES256_GCM,data:VZ3rSoFU3usjD/zBcq8Fs0io9jliiA3Os0viIILtCapL3+4RP8naHa8ZUDKqtLiI50fu1elYo+Zf8/u+WAnGPm3ti9V7IXRoKsh7jouLHRd7/myrTQ5UOmSA2V4oFD5OESBawSlb1W3qza/S9I67YiIUgxeconJ5WEboEZ31bgE=,iv:H9jwTGGqT6NzDeba+UfFLGCBV7kqZFwBYF+xWApINJQ=,tag:9m4X1xSHjgpJCBWi7lfx3g==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.10.2

--- a/shared/config.nix
+++ b/shared/config.nix
@@ -353,6 +353,23 @@ let
           "Must be a string";
     };
 
+    # Cloudflare Tunnel設定
+    cloudflare = {
+      # nixos-desktop用トンネル設定
+      desktop = {
+        cockpit = {
+          domain =
+            assertType "cloudflare.desktop.cockpit.domain" "desktop-cockpit.shinbunbun.com" builtins.isString
+              "Must be a string";
+        };
+        ttyd = {
+          domain =
+            assertType "cloudflare.desktop.ttyd.domain" "desktop-terminal.shinbunbun.com" builtins.isString
+              "Must be a string";
+        };
+      };
+    };
+
     # 管理インターフェース設定
     management = {
       # Cockpit設定

--- a/systems/nixos/configurations/nixos-desktop/default.nix
+++ b/systems/nixos/configurations/nixos-desktop/default.nix
@@ -29,6 +29,11 @@ in
     ../../modules/system-tools.nix
     ../../modules/desktop.nix
 
+    # 管理インターフェース
+    ../../modules/services/cockpit.nix
+    ../../modules/services/ttyd.nix
+    ../../modules/services/desktop-cloudflare-tunnel.nix
+
     # 外部モジュール
     inputs.home-manager.nixosModules.home-manager
     inputs.sops-nix.nixosModules.sops

--- a/systems/nixos/modules/services/cockpit.nix
+++ b/systems/nixos/modules/services/cockpit.nix
@@ -24,6 +24,7 @@ let
   enable = cfg.management.cockpit.enable;
   port = cfg.management.cockpit.port;
   domain = cfg.management.cockpit.domain;
+  desktopDomain = cfg.cloudflare.desktop.cockpit.domain or "";
   allowedNetworks = cfg.networking.allowedNetworks;
 in
 {
@@ -36,8 +37,13 @@ in
 
       settings = {
         WebService = {
-          # Origins設定でCORSを制御
-          Origins = lib.mkForce "https://${domain} wss://${domain}";
+          # Origins設定でCORSを制御 - 複数ドメインをサポート
+          Origins = lib.mkForce (
+            if desktopDomain != "" then
+              "https://${domain} wss://${domain} https://${desktopDomain} wss://${desktopDomain}"
+            else
+              "https://${domain} wss://${domain}"
+          );
           # プロトコルヘッダーを信頼（リバースプロキシ使用時）
           ProtocolHeader = "X-Forwarded-Proto";
           # ログインページのブランディング

--- a/systems/nixos/modules/services/desktop-cloudflare-tunnel.nix
+++ b/systems/nixos/modules/services/desktop-cloudflare-tunnel.nix
@@ -1,0 +1,86 @@
+/*
+  nixos-desktop用Cloudflare Tunnel設定
+
+  機能:
+  - nixos-desktop専用のトンネル設定
+  - CockpitとttydをCloudflare経由で公開
+  - SOPS統合による認証情報管理
+
+  注意:
+  - Cloudflare Zero Trust Accessの認証ポリシーは
+    別途Cloudflareダッシュボードまたは
+    Terraformで設定する必要があります
+*/
+{
+  config,
+  pkgs,
+  lib,
+  inputs,
+  ...
+}:
+let
+  cfg = import ../../../../shared/config.nix;
+  tunnelConfig = cfg.cloudflare.desktop;
+in
+{
+  # Cloudflare Tunnel設定
+  services.cloudflared = {
+    enable = true;
+    tunnels = {
+      "desktop-services" = {
+        default = "http_status:404";
+        credentialsFile = config.sops.templates."cloudflare/desktop-tunnel-credentials.json".path;
+
+        ingress = {
+          # Cockpit - Zero Trust Accessで認証必要
+          "${tunnelConfig.cockpit.domain}" = {
+            service = "http://localhost:${toString cfg.management.cockpit.port}";
+            originRequest = {
+              noTLSVerify = true;
+              httpHostHeader = "${tunnelConfig.cockpit.domain}";
+              originServerName = "${tunnelConfig.cockpit.domain}";
+            };
+          };
+
+          # ttyd Terminal - Zero Trust Accessで認証必要
+          "${tunnelConfig.ttyd.domain}" = {
+            service = "http://localhost:${toString cfg.management.ttyd.port}";
+            originRequest = {
+              noTLSVerify = true;
+              # WebSocket対応
+              httpHostHeader = "${tunnelConfig.ttyd.domain}";
+              originServerName = "${tunnelConfig.ttyd.domain}";
+            };
+          };
+        };
+      };
+    };
+  };
+
+  # SOPS設定
+  sops.secrets."cloudflare/desktop-account-tag" = {
+    sopsFile = "${inputs.self}/secrets/cloudflare.yaml";
+  };
+  sops.secrets."cloudflare/desktop-tunnel-id" = {
+    sopsFile = "${inputs.self}/secrets/cloudflare.yaml";
+  };
+  sops.secrets."cloudflare/desktop-tunnel-secret" = {
+    sopsFile = "${inputs.self}/secrets/cloudflare.yaml";
+  };
+
+  sops.templates."cloudflare/desktop-tunnel-credentials.json" = {
+    content = ''
+      {
+        "AccountTag": "${config.sops.placeholder."cloudflare/desktop-account-tag"}",
+        "TunnelID": "${config.sops.placeholder."cloudflare/desktop-tunnel-id"}",
+        "TunnelSecret": "${config.sops.placeholder."cloudflare/desktop-tunnel-secret"}"
+      }
+    '';
+  };
+
+  # systemd設定
+  systemd.services."cloudflared-tunnel-desktop-services" = {
+    after = [ "network-online.target" ];
+    wants = [ "network-online.target" ];
+  };
+}


### PR DESCRIPTION
## Summary
- nixos-desktopにWebベースの管理ツール（Cockpit、ttyd）を追加
- Cloudflare Tunnel経由でセキュアにアクセス可能に設定
- Closes #142

## 変更内容
- **Cockpit**: ポート9091でWebベースのサーバー管理インターフェースを提供
- **ttyd**: ポート7681でWebベースのターミナルエミュレータを提供
- **Cloudflare Tunnel**: desktop-services トンネルを新規作成
  - desktop-cockpit.shinbunbun.com
  - desktop-terminal.shinbunbun.com
- CockpitのOrigins設定を複数ドメイン対応に修正

## Test plan
- [x] `nix flake check` が成功
- [x] `nix fmt` でフォーマット済み
- [x] `nix build .#nixosConfigurations.nixos-desktop.config.system.build.toplevel` が成功
- [x] nixos-desktopマシンで `nixos-rebuild switch` を実行
- [x] Cockpitへのアクセス確認
- [x] ttydへのアクセス確認