### PR TITLE
fix: Darwin環境でWireGuardが動作しない問題を修正

### DIFF
--- a/systems/darwin/modules/wireguard.nix
+++ b/systems/darwin/modules/wireguard.nix
@@ -2,7 +2,8 @@
   Darwin WireGuard設定
 
   macOS用のWireGuard VPN設定を提供します。
-  SOPSを使用した安全な鍵管理を行います。
+  Home-Manager経由でSOPSテンプレートを生成し、
+  システムレベルでWireGuardが使用できるようにします。
 */
 {
   config,
@@ -14,23 +15,72 @@
 
 let
   cfg = import ../../../shared/config.nix;
-  sopsWireGuardHelper = import ../../../secrets/wireguard-helper.nix { inherit inputs; };
-in
-sopsWireGuardHelper.mkSopsWireGuardConfig { inherit config pkgs lib; } {
-  sopsFile = "${inputs.self}/secrets/wireguard.yaml";
-  privateKeyPath = cfg.wireguard.darwin.privateKeyPath;
-  publicKeyPath = cfg.wireguard.darwin.publicKeyPath;
-  endpointPath = cfg.wireguard.darwin.endpointPath;
+  username = cfg.users.darwin.username;
   interfaceName = cfg.wireguard.darwin.interfaceName;
-  interfaceAddress = "${cfg.wireguard.darwin.clientIp}/32";
-  peerAllowedIPs = cfg.wireguard.darwin.allowedNetworks ++ [ "${cfg.wireguard.network.serverIp}/32" ];
-  persistentKeepalive = cfg.wireguard.persistentKeepalive;
-  isDarwin = true;
-}
-// {
-  # Darwin用のSOPS基本設定
-  sops = {
-    defaultSopsFile = "${inputs.self}/secrets/wireguard.yaml";
-    age.keyFile = cfg.sops.keyFile;
+  homeDir = cfg.users.darwin.homeDirectory;
+  wireguardConfigPath = "${homeDir}/.config/wireguard/${interfaceName}.conf";
+in
+{
+  # WireGuardツールのインストール
+  environment.systemPackages = [ pkgs.wireguard-tools ];
+
+  # Home-Manager内でSOPSテンプレートを設定
+  home-manager.users.${username} = { config, ... }: {
+    imports = [ inputs.sops-nix.homeManagerModules.sops ];
+
+    sops = {
+      defaultSopsFile = "${inputs.self}/secrets/wireguard.yaml";
+      age.keyFile = cfg.sops.keyFile;
+      
+      # 個別のシークレット定義
+      secrets = {
+        "wireguard/home/macClientPrivKey" = { };
+        "wireguard/home/publicKey" = { };
+        "wireguard/home/endpoint" = { };
+      };
+
+      # WireGuard設定テンプレート
+      templates."wireguard-config" = {
+        content = ''
+          [Interface]
+          PrivateKey = ${config.sops.placeholder."wireguard/home/macClientPrivKey"}
+          Address = ${cfg.wireguard.darwin.clientIp}/32
+
+          [Peer]
+          PublicKey = ${config.sops.placeholder."wireguard/home/publicKey"}
+          Endpoint = ${config.sops.placeholder."wireguard/home/endpoint"}
+          AllowedIPs = ${lib.concatStringsSep ", " (cfg.wireguard.darwin.allowedNetworks ++ [ "${cfg.wireguard.network.serverIp}/32" ])}
+          PersistentKeepalive = ${toString cfg.wireguard.persistentKeepalive}
+        '';
+        path = wireguardConfigPath;
+        mode = "0600";
+      };
+    };
+
+    # WireGuard管理用のエイリアス
+    programs.zsh.shellAliases = {
+      wg-up = "sudo wg-quick up ${interfaceName}";
+      wg-down = "sudo wg-quick down ${interfaceName}";
+      wg-status = "sudo wg show ${interfaceName}";
+    };
   };
+
+  # システムレベルでWireGuard設定をセットアップ
+  system.activationScripts.postActivation.text = lib.mkAfter ''
+    echo "Setting up WireGuard configuration..." >&2
+    
+    # 設定ディレクトリ作成
+    mkdir -p /usr/local/etc/wireguard
+    
+    # Home-Managerが生成した設定ファイルが存在するか確認
+    if [ -f "${wireguardConfigPath}" ]; then
+      # システムレベルにコピー
+      cp "${wireguardConfigPath}" "/usr/local/etc/wireguard/${interfaceName}.conf"
+      chmod 600 "/usr/local/etc/wireguard/${interfaceName}.conf"
+      echo "WireGuard configuration copied to /usr/local/etc/wireguard/${interfaceName}.conf" >&2
+    else
+      echo "Warning: WireGuard configuration not found at ${wireguardConfigPath}" >&2
+      echo "Home-Manager activation may be needed first" >&2
+    fi
+  '';
 }


### PR DESCRIPTION
## Summary
- sops-nixのDarwinサポートが不完全でテンプレート機能が動作しない問題を修正
- Home-Manager経由でSOPSテンプレートを生成し、システムレベルでWireGuardが使用可能になるよう実装

## 変更内容
- `wireguard-helper.nix`の使用を廃止
- Home-ManagerのSOPSモジュールを使用してテンプレート生成
- システムactivation scriptでWireGuard設定を`/usr/local/etc/wireguard/`にコピー
- WireGuard管理用のシェルエイリアス（`wg-up`, `wg-down`, `wg-status`）を追加

## 解決した問題
- `sudo wg-quick up wg-home`で以下のエラーが発生していた問題を解決:
  ```
  .wg-quick-wrapped: `/usr/local/etc/wireguard/wg-home.conf' does not exist
  ```

## Test plan
- [x] Darwin設定のビルドが成功すること
- [x] Home-ManagerのSOPSが正常にテンプレートを生成すること  
- [x] システムレベルにWireGuard設定がコピーされること
- [x] `sudo wg-quick up wg-home`でWireGuardが正常に起動すること

## 注意事項
初回セットアップ時、Age鍵ファイルの権限設定が必要:
```bash
sudo chmod 644 /var/lib/sops-nix/key.txt
```