### PR TITLE
feat: 開発ツールにTerraformを追加

### DIFF
--- a/home/modules/development/development-tools.nix
+++ b/home/modules/development/development-tools.nix
@@ -3,12 +3,18 @@
 
   このモジュールは開発に必要なツールを提供します：
   - cocoapods: iOS/macOSアプリ開発用のパッケージマネージャー
+  - terraform: インフラストラクチャを code として管理するツール
 
-  モバイルアプリ開発やその他の開発用ツールが含まれます。
+  モバイルアプリ開発やインフラ管理のツールが含まれます。
 */
 { pkgs, ... }:
 {
-  home.packages = pkgs.lib.optionals pkgs.stdenv.isDarwin [
-    pkgs.cocoapods
-  ];
+  home.packages =
+    with pkgs;
+    [
+      terraform
+    ]
+    ++ lib.optionals stdenv.isDarwin [
+      cocoapods
+    ];
 }


### PR DESCRIPTION
## Summary
- LinuxとmacOSの両方で使用可能なインフラ管理ツールとしてTerraformを追加
- 既存のcocoapodsはmacOS専用のまま維持

## Test plan
- [x] nix flake check で設定ファイルの構文チェック
- [x] nix fmt でコードフォーマット
- [x] nix build .#darwinConfigurations.macbook.system でビルド確認