### PR TITLE
異常ウォールダッシュボードにホスト選択機能を追加

### DIFF
--- a/systems/nixos/modules/services/dashboards/anomaly-wall.json
+++ b/systems/nixos/modules/services/dashboards/anomaly-wall.json
@@ -415,7 +415,7 @@
         "enableLogDetails": true,
         "prettifyLogMessage": false,
         "showCommonLabels": false,
-        "showLabels": false,
+        "showLabels": true,
         "showTime": true,
         "sortOrder": "Descending",
         "wrapLogMessage": false
@@ -426,7 +426,7 @@
             "type": "loki",
             "uid": "${loki_datasource}"
           },
-          "expr": "{level=~\"error|ERROR|critical|CRITICAL\"}",
+          "expr": "{host=~\"$host\", level=~\"error|ERROR|critical|CRITICAL\"}",
           "refId": "A"
         }
       ],
@@ -477,6 +477,38 @@
         "regex": "",
         "skipUrlSync": false,
         "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "hide": 0,
+        "includeAll": true,
+        "multi": false,
+        "name": "host",
+        "options": [
+          {
+            "selected": true,
+            "text": "All",
+            "value": "$__all"
+          },
+          {
+            "selected": false,
+            "text": "nixos",
+            "value": "nixos"
+          },
+          {
+            "selected": false,
+            "text": "nixos-desktop",
+            "value": "nixos-desktop"
+          }
+        ],
+        "query": "nixos,nixos-desktop",
+        "skipUrlSync": false,
+        "type": "custom",
+        "allValue": ".*"
       }
     ]
   },


### PR DESCRIPTION
## Summary
- Grafanaの異常ウォールダッシュボードにホスト選択用のテンプレート変数を追加
- 最新エラーログパネルのLokiクエリにhostフィルタを追加
- ログパネルでhostラベルを表示するよう設定

## 変更内容
### ホスト選択機能の追加
- ドロップダウンで「All」「nixos」「nixos-desktop」を選択可能に
- デフォルトは「All」で全ホストのログを表示

### Lokiクエリの改善
- クエリに`host=~"$host"`フィルタを追加
- 選択したホストのエラーログのみを表示

### ログ表示の改善
- `showLabels: true`に設定し、ホストラベルを表示
- どのホストからのログか一目でわかるように改善

## 解決する問題
nixos-desktopのログがnixosサーバーのログと混在して確認しづらかった問題を解決。
特定のホストを選択してログを表示できるようになりました。

## Test plan
- [ ] Grafanaダッシュボードでホスト選択ドロップダウンが表示されることを確認
- [ ] 「nixos-desktop」を選択してデスクトップのエラーログのみが表示されることを確認
- [ ] 「All」を選択して全ホストのログが表示されることを確認
- [ ] ログにhostラベルが表示されることを確認