### PR TITLE
fix: CouchDB初期化問題を修正（Obsidian LiveSync）

### DIFF
--- a/systems/nixos/modules/services/obsidian-livesync.nix
+++ b/systems/nixos/modules/services/obsidian-livesync.nix
@@ -139,8 +139,8 @@
   # CouchDBデータディレクトリの作成
   systemd.tmpfiles.rules = [
     "d /var/lib/couchdb 0755 root root -"
-    "d /var/lib/couchdb/data 0755 999 999 -"
-    "d /var/lib/couchdb/config 0755 999 999 -"
+    "d /var/lib/couchdb/data 0755 5984 5984 -"
+    "d /var/lib/couchdb/config 0755 5984 5984 -"
   ];
 
   # CouchDB OCI Container
@@ -219,6 +219,13 @@
         ${pkgs.curl}/bin/curl -f --netrc-file "$NETRC_FILE" \
           -X PUT http://localhost:5984/$DATABASE_NAME 2>/dev/null || {
           echo "Database $DATABASE_NAME already exists or creation failed"
+        }
+
+        # Create _users system database to silence auth cache warnings
+        echo "Creating _users system database..."
+        ${pkgs.curl}/bin/curl -f --netrc-file "$NETRC_FILE" \
+          -X PUT http://localhost:5984/_users 2>/dev/null || {
+          echo "Database _users already exists or creation failed"
         }
 
         # Configure CORS settings via CouchDB API


### PR DESCRIPTION
## Summary
- CouchDB UID/GID問題を修正してパーミッションエラーを解消
- _usersシステムデータベース作成を追加してauth cacheエラーを解消
- Obsidian LiveSyncの接続問題を完全に解決

## 変更内容

### 1. UID/GIDの修正
- systemd tmpfiles設定のUID/GIDを999:999から5984:5984に変更
- これによりCouchDBコンテナ内のcouchdbユーザー（UID 5984）と一致
- パーミッションエラー`{error,eacces}`が解消

### 2. _usersデータベースの作成
- CouchDBの`_users`システムデータベースを初期化時に作成
- `chttpd_auth_cache changes listener died`エラーが解消
- CouchDB認証キャッシュが正常に動作

## テスト結果
- ✅ CouchDBコンテナが正常に起動
- ✅ データベース初期化が成功
- ✅ Obsidian LiveSyncから接続成功
- ✅ 複数デバイス間で同期が正常に動作
- ✅ エラーログが完全に解消