### PR TITLE
feat: OpenSearch DashboardsをCloudflare Tunnel経由で公開 (#200)

### DIFF
--- a/systems/nixos/modules/services/desktop-cloudflare-tunnel.nix
+++ b/systems/nixos/modules/services/desktop-cloudflare-tunnel.nix
@@ -3,7 +3,7 @@
 
   機能:
   - nixos-desktop専用のトンネル設定
-  - CockpitとttydをCloudflare経由で公開
+  - Cockpit、ttyd、OpenSearch DashboardsをCloudflare経由で公開
   - SOPS統合による認証情報管理
 
   注意:
@@ -50,6 +50,16 @@ in
               # WebSocket対応
               httpHostHeader = "${tunnelConfig.ttyd.domain}";
               originServerName = "${tunnelConfig.ttyd.domain}";
+            };
+          };
+
+          # OpenSearch Dashboards - Zero Trust Accessで認証必要
+          "${cfg.opensearchDashboards.domain}" = {
+            service = "http://localhost:${toString cfg.opensearchDashboards.port}";
+            originRequest = {
+              noTLSVerify = true;
+              httpHostHeader = "${cfg.opensearchDashboards.domain}";
+              originServerName = "${cfg.opensearchDashboards.domain}";
             };
           };
         };


### PR DESCRIPTION
## 概要

Issue #200のPhase 1実装として、OpenSearch DashboardsをCloudflare Tunnel経由で公開するための設定を追加しました。

## 変更内容

### NixOS設定
- `systems/nixos/modules/services/desktop-cloudflare-tunnel.nix`にOpenSearch Dashboards用のingress設定を追加
- `shared/config.nix`で定義済みのドメイン設定を使用
- Cloudflare Zero Trust Accessで認証が必要

## 動作確認

- ✅ `nix flake check` - 構文チェック成功
- ✅ `nix fmt` - フォーマット済み
- ✅ `nix build` - ビルド確認成功

## デプロイ手順

### nixos-desktopでの適用

```bash
# nixos-desktopに適用
sudo nixos-rebuild switch --flake .#nixos-desktop

# サービス確認
sudo systemctl status cloudflared-tunnel-desktop-services
```

## 関連Issue

Closes #200