### PR TITLE
fix: Fluent Bitのログレベルを数値から文字列に変換

### DIFF
--- a/systems/nixos/modules/services/fluent-bit.nix
+++ b/systems/nixos/modules/services/fluent-bit.nix
@@ -53,7 +53,7 @@ let
         Add                 host ${hostname}
         Add                 log_type systemd
 
-    # ログレベルの正規化
+    # ログレベルの正規化（フィールド名変更）
     [FILTER]
         Name                modify
         Match               journal.*
@@ -61,6 +61,55 @@ let
         Rename              MESSAGE message
         Rename              SYSLOG_IDENTIFIER service
         Rename              _SYSTEMD_UNIT unit
+
+    # ログレベルの数値→文字列変換（systemd PRIORITYは0-7の数値）
+    [FILTER]
+        Name                modify
+        Match               journal.*
+        Condition           Key_Value_Equals level 0
+        Set                 level emergency
+
+    [FILTER]
+        Name                modify
+        Match               journal.*
+        Condition           Key_Value_Equals level 1
+        Set                 level alert
+
+    [FILTER]
+        Name                modify
+        Match               journal.*
+        Condition           Key_Value_Equals level 2
+        Set                 level critical
+
+    [FILTER]
+        Name                modify
+        Match               journal.*
+        Condition           Key_Value_Equals level 3
+        Set                 level error
+
+    [FILTER]
+        Name                modify
+        Match               journal.*
+        Condition           Key_Value_Equals level 4
+        Set                 level warning
+
+    [FILTER]
+        Name                modify
+        Match               journal.*
+        Condition           Key_Value_Equals level 5
+        Set                 level notice
+
+    [FILTER]
+        Name                modify
+        Match               journal.*
+        Condition           Key_Value_Equals level 6
+        Set                 level info
+
+    [FILTER]
+        Name                modify
+        Match               journal.*
+        Condition           Key_Value_Equals level 7
+        Set                 level debug
 
     # 不要なフィールドの削除
     [FILTER]


### PR DESCRIPTION
systemd-journalのPRIORITYフィールド（0-7の数値）を
人間が読める文字列（emergency, alert, critical, error等）に
変換するフィルターを追加。

これにより、OpenSearch Dashboardsでログレベルによる
検索・フィルタリングが容易になる。

変換マッピング:
- 0 → emergency
- 1 → alert
- 2 → critical
- 3 → error
- 4 → warning
- 5 → notice
- 6 → info
- 7 → debug