### PR TITLE
fix: WireGuardインターフェース再起動時の競合を解決

### DIFF
--- a/secrets/wireguard-helper.nix
+++ b/secrets/wireguard-helper.nix
@@ -81,6 +81,16 @@ let
       networking.wg-quick.interfaces.${interfaceName} = {
         configFile = configPath;
       };
+
+      # wg-quickサービスの再起動時に既存のインターフェースを適切に処理
+      systemd.services."wg-quick-${interfaceName}" = {
+        preStart = lib.mkBefore ''
+          # 既存のインターフェースが存在する場合は削除
+          if ${pkgs.iproute2}/bin/ip link show ${interfaceName} >/dev/null 2>&1; then
+            ${pkgs.iproute2}/bin/ip link delete ${interfaceName} || true
+          fi
+        '';
+      };
     });
 in
 {


### PR DESCRIPTION
## 概要
- システム再構築時に`wg-quick-wg0.service`が「wg0 already exists」エラーで失敗する問題を修正

## 変更内容
- `secrets/wireguard-helper.nix`にsystemdサービスの`preStart`フックを追加
- サービス起動前に既存のWireGuardインターフェースを削除することで冪等性を確保

## 技術的詳細
systemd サービスの起動前に以下の処理を実行:
1. `ip link show`でインターフェースの存在確認
2. 既存のインターフェースがあれば`ip link delete`で削除
3. `|| true`でエラーを無視し、処理を継続

## テスト
- [x] `nix flake check` - 構文チェック通過
- [x] `nix build` - ビルド成功
- [ ] `sudo nixos-rebuild switch` - 実機での動作確認が必要