### PR TITLE
fix: Git設定の非推奨オプションを新しいフォーマットに更新

### DIFF
--- a/home/modules/shell/version-control.nix
+++ b/home/modules/shell/version-control.nix
@@ -18,10 +18,11 @@ in
   programs.git = {
     enable = true;
 
-    userName = configValues.git.userName;
-    userEmail = configValues.git.userEmail;
-
-    extraConfig = {
+    settings = {
+      user = {
+        name = configValues.git.userName;
+        email = configValues.git.userEmail;
+      };
       core.editor = configValues.git.coreEditor;
     };
   };


### PR DESCRIPTION
## 概要
nixos-rebuild時に表示されていたGit設定の非推奨警告を修正しました。

## 変更内容
`home/modules/shell/version-control.nix`で以下のオプションを更新:
- `programs.git.userName` → `programs.git.settings.user.name`
- `programs.git.userEmail` → `programs.git.settings.user.email`
- `programs.git.extraConfig` → `programs.git.settings`に統合

## 解消された警告
```
evaluation warning: bunbun profile: The option `programs.git.userEmail' defined in `.../version-control.nix' has been renamed to `programs.git.settings.user.email'.
evaluation warning: bunbun profile: The option `programs.git.userName' defined in `.../version-control.nix' has been renamed to `programs.git.settings.user.name'.
evaluation warning: bunbun profile: The option `programs.git.extraConfig' defined in `.../version-control.nix' has been renamed to `programs.git.settings'.
```