### PR TITLE
feat: 新しいSSD (WD Blue SN5000 1TB) を /mnt/storage にマウント

### DIFF
--- a/systems/nixos/configurations/nixos-desktop/hardware.nix
+++ b/systems/nixos/configurations/nixos-desktop/hardware.nix
@@ -36,6 +36,11 @@
     fsType = "vfat";
   };
 
+  fileSystems."/mnt/storage" = {
+    device = "/dev/disk/by-uuid/2be58efc-54f9-4014-8232-f9b6fad78826";
+    fsType = "ext4";
+  };
+
   swapDevices = [
     { device = "/dev/disk/by-uuid/767db5a0-fe74-41fa-a4d5-4ebb133a0052"; }
   ];


### PR DESCRIPTION
データストレージ用に1TBのSSDを追加し、/mnt/storageに自動マウントするよう設定。

- デバイス: /dev/nvme1n1 (WD Blue SN5000 1TB)
- マウントポイント: /mnt/storage
- ファイルシステム: ext4
- 利用可能容量: 870GB