### PR TITLE
fix: デプロイ用SSHポートを31415に修正

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -272,6 +272,7 @@ jobs:
           cat >> ~/.ssh/config << 'EOF'
           Host homemachine
             HostName 192.168.1.3
+            Port 31415
             User deploy
             IdentityFile ~/.ssh/deploy_key
             StrictHostKeyChecking no

--- a/flake.nix
+++ b/flake.nix
@@ -239,8 +239,8 @@
       # deploy-rs設定
       deploy.nodes = {
         homeMachine = {
-          hostname = "homemachine"; # SSH config の Host名（Cloudflare Tunnel経由）
-          fastConnection = false; # Tunnel経由なのでfalse
+          hostname = "homemachine"; # SSH config の Host名（WireGuard VPN経由）
+          fastConnection = false; # WireGuard VPN経由なのでfalse
           interactiveSudo = false;
           remoteBuild = true; # リモートマシンでビルド（deployユーザーはtrusted-user）
 


### PR DESCRIPTION
SSH設定にPort指定がなくデフォルトの22番で接続を試みていたため、
デプロイジョブのSSH接続テストが2分でタイムアウトしていた。
併せてflake.nixのコメントをCloudflare TunnelからWireGuard VPNに更新。