### PR TITLE
fix: deployユーザーのsudo権限をALLに変更

### DIFF
--- a/systems/nixos/modules/services/deploy-user.nix
+++ b/systems/nixos/modules/services/deploy-user.nix
@@ -48,20 +48,13 @@ in
   # Nix trusted-user設定（クロージャ転送のため必要）
   nix.settings.trusted-users = [ cfg.deploy.user ];
 
-  # NOPASSWD sudo権限
-  # deploy-rs は activation 時に様々なシステムコマンドを sudo で実行するため、
-  # 適切な権限が必要。以下のアプローチでバランスを取る：
-  # /nix/store/* 内のコマンドはすべて許可（これらは暗号学的に検証済みで不変）
-  # /run/current-system/sw/bin/* も /nix/store/* へのシンボリックリンクなので、
-  # この単一のルールで必要なすべてのコマンドをカバーできる。
-  # セキュリティは SSH 公開鍵認証とネットワークアクセス制限でさらに担保する。
+  # deploy-rs用のNOPASSWD sudo権限
   security.sudo.extraRules = [
     {
       users = [ cfg.deploy.user ];
       commands = [
-        # Nixストア内のすべてのコマンドを許可（これらは暗号的に検証済みで不変）
         {
-          command = "/nix/store/*";
+          command = "ALL";
           options = [ "NOPASSWD" ];
         }
       ];


### PR DESCRIPTION
## 概要
sudoersのワイルドカード（`*`）はスラッシュにマッチしないため、`/nix/store/*` では `/nix/store/xxx/bin/cmd` のようなパスにマッチしない問題を修正。

## 変更内容
- `command = "/nix/store/*"` → `command = "ALL"` に変更

## 注意
マージ後、サーバーで手動で `nixos-rebuild switch` を実行する必要があります（鶏と卵問題のため）。