### PR TITLE
perf: Atticキャッシュのpush/fetch速度を改善

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,7 @@ jobs:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |
             experimental-features = nix-command flakes
-            substituters = https://cache.nixos.org http://192.168.1.3:8080/main
+            substituters = https://cache.nixos.org https://cache.shinbunbun.com/main
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= main:EMoov6FniyxjYhY24OcZ02dOIWKu4feJH7uGRjgwwUc=
             netrc-file = /etc/nix/netrc
             fallback = true
@@ -65,7 +65,7 @@ jobs:
 
       - name: Setup Attic authentication
         run: |
-          echo "machine 192.168.1.3 password ${{ secrets.ATTIC_READ_TOKEN }}" | sudo tee /etc/nix/netrc > /dev/null
+          echo "machine cache.shinbunbun.com password ${{ secrets.ATTIC_READ_TOKEN }}" | sudo tee /etc/nix/netrc > /dev/null
           sudo chmod 600 /etc/nix/netrc
 
       - name: Build NixOS configuration
@@ -84,16 +84,16 @@ jobs:
 
           # attic CLI自体をキャッシュにプッシュ（次回CI実行でキャッシュヒット）
           echo "Pushing attic-cli to cache..."
-          ./attic-cli/bin/attic push main attic-cli || echo "Failed to push attic-cli (non-fatal)"
+          ./attic-cli/bin/attic push -j 3 main attic-cli || echo "Failed to push attic-cli (non-fatal)"
 
           # deploy-rs CLIをキャッシュにプッシュ（deployジョブでキャッシュヒット）
           echo "Pushing deploy-rs to cache..."
           nix build .#deploy-rs --out-link deploy-rs-cli
-          ./attic-cli/bin/attic push main deploy-rs-cli || echo "Failed to push deploy-rs (non-fatal)"
+          ./attic-cli/bin/attic push -j 3 main deploy-rs-cli || echo "Failed to push deploy-rs (non-fatal)"
 
           # システムビルドをキャッシュにプッシュ
           echo "Pushing system build to cache..."
-          ./attic-cli/bin/attic push main result-${{ matrix.configuration }} || echo "Failed to push system build (non-fatal)"
+          ./attic-cli/bin/attic push -j 3 main result-${{ matrix.configuration }} || echo "Failed to push system build (non-fatal)"
         continue-on-error: true
 
       - name: Teardown WireGuard VPN
@@ -124,7 +124,7 @@ jobs:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |
             experimental-features = nix-command flakes
-            substituters = https://cache.nixos.org http://192.168.1.3:8080/main
+            substituters = https://cache.nixos.org https://cache.shinbunbun.com/main
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= main:EMoov6FniyxjYhY24OcZ02dOIWKu4feJH7uGRjgwwUc=
             netrc-file = /etc/nix/netrc
             fallback = true
@@ -138,7 +138,7 @@ jobs:
 
       - name: Setup Attic authentication
         run: |
-          echo "machine 192.168.1.3 password ${{ secrets.ATTIC_READ_TOKEN }}" | sudo tee /etc/nix/netrc > /dev/null
+          echo "machine cache.shinbunbun.com password ${{ secrets.ATTIC_READ_TOKEN }}" | sudo tee /etc/nix/netrc > /dev/null
           sudo chmod 600 /etc/nix/netrc
 
       - name: Build Darwin configuration
@@ -157,11 +157,11 @@ jobs:
 
           # attic CLI自体をキャッシュにプッシュ（次回CI実行でキャッシュヒット）
           echo "Pushing attic-cli to cache..."
-          ./attic-cli/bin/attic push main attic-cli || echo "Failed to push attic-cli (non-fatal)"
+          ./attic-cli/bin/attic push -j 3 main attic-cli || echo "Failed to push attic-cli (non-fatal)"
 
           # Darwinビルドをキャッシュにプッシュ
           echo "Pushing Darwin build to cache..."
-          ./attic-cli/bin/attic push main result-${{ matrix.configuration }} || echo "Failed to push Darwin build (non-fatal)"
+          ./attic-cli/bin/attic push -j 3 main result-${{ matrix.configuration }} || echo "Failed to push Darwin build (non-fatal)"
         continue-on-error: true
 
       - name: Teardown WireGuard VPN
@@ -189,7 +189,7 @@ jobs:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |
             experimental-features = nix-command flakes
-            substituters = https://cache.nixos.org http://192.168.1.3:8080/main
+            substituters = https://cache.nixos.org https://cache.shinbunbun.com/main
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= main:EMoov6FniyxjYhY24OcZ02dOIWKu4feJH7uGRjgwwUc=
             netrc-file = /etc/nix/netrc
             fallback = true
@@ -197,7 +197,7 @@ jobs:
 
       - name: Setup Attic authentication
         run: |
-          echo "machine 192.168.1.3 password ${{ secrets.ATTIC_READ_TOKEN }}" | sudo tee /etc/nix/netrc > /dev/null
+          echo "machine cache.shinbunbun.com password ${{ secrets.ATTIC_READ_TOKEN }}" | sudo tee /etc/nix/netrc > /dev/null
           sudo chmod 600 /etc/nix/netrc
 
       - name: Build development shell
@@ -216,11 +216,11 @@ jobs:
 
           # attic CLI自体をキャッシュにプッシュ（次回CI実行でキャッシュヒット）
           echo "Pushing attic-cli to cache..."
-          ./attic-cli/bin/attic push main attic-cli || echo "Failed to push attic-cli (non-fatal)"
+          ./attic-cli/bin/attic push -j 3 main attic-cli || echo "Failed to push attic-cli (non-fatal)"
 
           # devshellビルドをキャッシュにプッシュ
           echo "Pushing devshell build to cache..."
-          ./attic-cli/bin/attic push main result-devshell || echo "Failed to push devshell build (non-fatal)"
+          ./attic-cli/bin/attic push -j 3 main result-devshell || echo "Failed to push devshell build (non-fatal)"
         continue-on-error: true
 
       - name: Teardown WireGuard VPN
@@ -267,7 +267,7 @@ jobs:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |
             experimental-features = nix-command flakes
-            substituters = https://cache.nixos.org http://192.168.1.3:8080/main
+            substituters = https://cache.nixos.org https://cache.shinbunbun.com/main
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= main:EMoov6FniyxjYhY24OcZ02dOIWKu4feJH7uGRjgwwUc=
             netrc-file = /etc/nix/netrc
             fallback = true
@@ -275,7 +275,7 @@ jobs:
 
       - name: Setup Attic authentication
         run: |
-          echo "machine 192.168.1.3 password ${{ secrets.ATTIC_READ_TOKEN }}" | sudo tee /etc/nix/netrc > /dev/null
+          echo "machine cache.shinbunbun.com password ${{ secrets.ATTIC_READ_TOKEN }}" | sudo tee /etc/nix/netrc > /dev/null
           sudo chmod 600 /etc/nix/netrc
 
       - name: Setup SSH for deployment

--- a/shared/config.nix
+++ b/shared/config.nix
@@ -562,18 +562,26 @@ let
 
       # チャンク設定
       chunking = {
-        narSizeThreshold = assertType "attic.chunking.narSizeThreshold" 65536 (
+        narSizeThreshold = assertType "attic.chunking.narSizeThreshold" 131072 (
           n: builtins.isInt n && n > 0
-        ) "Must be a positive integer (bytes)"; # 64 KiB
-        minSize = assertType "attic.chunking.minSize" 16384 (
+        ) "Must be a positive integer (bytes)"; # 128 KiB
+        minSize = assertType "attic.chunking.minSize" 32768 (
           n: builtins.isInt n && n > 0
-        ) "Must be a positive integer (bytes)"; # 16 KiB
-        avgSize = assertType "attic.chunking.avgSize" 65536 (
+        ) "Must be a positive integer (bytes)"; # 32 KiB
+        avgSize = assertType "attic.chunking.avgSize" 131072 (
           n: builtins.isInt n && n > 0
-        ) "Must be a positive integer (bytes)"; # 64 KiB
-        maxSize = assertType "attic.chunking.maxSize" 262144 (
+        ) "Must be a positive integer (bytes)"; # 128 KiB
+        maxSize = assertType "attic.chunking.maxSize" 524288 (
           n: builtins.isInt n && n > 0
-        ) "Must be a positive integer (bytes)"; # 256 KiB
+        ) "Must be a positive integer (bytes)"; # 512 KiB
+      };
+
+      # 圧縮設定
+      compression = {
+        type = assertType "attic.compression.type" "zstd" builtins.isString "Must be a string";
+        level = assertType "attic.compression.level" 3 (
+          n: builtins.isInt n && n >= 1 && n <= 22
+        ) "Must be an integer between 1 and 22";
       };
     };
 

--- a/systems/nixos/modules/services/attic.nix
+++ b/systems/nixos/modules/services/attic.nix
@@ -104,8 +104,8 @@ in
       };
 
       compression = {
-        type = "zstd";
-        level = 8;
+        type = cfg.attic.compression.type;
+        level = cfg.attic.compression.level;
       };
 
       garbage-collection = {


### PR DESCRIPTION
- fetchをCloudflare Tunnel経由に変更（cache.shinbunbun.com）してwireguard-goボトルネックを回避
- attic pushに-j 3フラグを追加して並列転送を有効化
- zstd圧縮レベルを8→3に変更して圧縮速度を改善
- チャンクサイズを2倍に増加してHTTPリクエスト数を削減