### PR TITLE
atticd tmpfilesのレースコンディション修正と不要なk8sディスク・NFS設定を削除

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -292,11 +292,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1769354340,
-        "narHash": "sha256-/Hayjw7OVUxLGheitH+5H5/8HKYyH5zYIQJb8TqI5Ks=",
+        "lastModified": 1771574314,
+        "narHash": "sha256-cuFU7tnDUwLeT/4YQ619xcjzZlVfoX2LEMs54u9nl6I=",
         "owner": "shinbunbun",
         "repo": "nixos-observability-config",
-        "rev": "21c42f032792f05d45880c08affc4bbc4f8d4cb4",
+        "rev": "85672b988c06696291d812c0b8ed71a3a8eeb552",
         "type": "github"
       },
       "original": {

--- a/systems/nixos/configurations/homeMachine/default.nix
+++ b/systems/nixos/configurations/homeMachine/default.nix
@@ -32,7 +32,6 @@ in
     ../../modules/security.nix
     ../../modules/system-tools.nix
     ../../modules/wireguard.nix
-    ../../modules/nfs.nix
 
     # サービスモジュール
     ../../modules/services/services.nix

--- a/systems/nixos/configurations/homeMachine/hardware.nix
+++ b/systems/nixos/configurations/homeMachine/hardware.nix
@@ -37,20 +37,6 @@
     fsType = "vfat";
   };
 
-  fileSystems."/mnt/k8s" = {
-    device = "/dev/disk/by-uuid/dc37e1f6-c488-4491-b524-96fc14e27a92";
-    fsType = "ext4";
-    options = [ "nofail" ];
-  };
-
-  fileSystems."/export/k8s" = {
-    device = "/mnt/k8s";
-    options = [
-      "bind"
-      "nofail"
-    ];
-  };
-
   swapDevices = [
     { device = "/dev/disk/by-uuid/42a8faf1-0f52-476e-a6d9-1fd777514493"; }
   ];

--- a/systems/nixos/modules/services/attic.nix
+++ b/systems/nixos/modules/services/attic.nix
@@ -115,10 +115,12 @@ in
     };
   };
 
-  # データディレクトリの作成
+  # ストレージディレクトリの作成
+  # atticdはDynamicUserのため、rebuild時にユーザーが存在しない場合がある
+  # root所有で作成し、サービス側のReadWritePathsで書き込み権限を確保
+  # /var/lib/atticdはDynamicUserが自動管理（symlink → private/atticd）するため不要
   systemd.tmpfiles.rules = [
-    "d ${storagePath} 0755 atticd atticd -"
-    "d /var/lib/atticd 0755 atticd atticd -"
+    "d ${storagePath} 0755 root root -"
   ];
 
   # systemd設定の調整（Atticモジュールのデフォルトを拡張）
@@ -129,6 +131,9 @@ in
     ];
     wants = [ "network-online.target" ];
     requires = [ "postgresql.service" ];
+    serviceConfig = {
+      ReadWritePaths = [ storagePath ];
+    };
   };
 
   # ファイアウォール設定


### PR DESCRIPTION
- atticd tmpfilesルールのオーナーをroot:rootに変更し、DynamicUser不在時のエラーを回避
- /var/lib/atticdはDynamicUserが自動管理するためtmpfilesルールから除外
- atticdサービスにReadWritePathsを追加してストレージへの書き込み権限を確保
- 存在しないk8sディスク(/mnt/k8s)とbind mount(/export/k8s)の定義を削除
- NFSモジュールのインポートを削除（エクスポート先が無くなったため）
- nixos-observability-configのflake inputを更新（Fluent Bitログレベル修正を含む）