### PR TITLE
Mac Mini用のDarwin設定を追加

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -147,6 +147,13 @@
             ./systems/darwin/configurations/macbook/default.nix
           ];
         };
+        macmini = nix-darwin.lib.darwinSystem {
+          system = "aarch64-darwin";
+          specialArgs = { inherit inputs; };
+          modules = [
+            ./systems/darwin/configurations/macmini/default.nix
+          ];
+        };
       };
 
       # 開発シェル

--- a/systems/darwin/configurations/macbook/default.nix
+++ b/systems/darwin/configurations/macbook/default.nix
@@ -31,6 +31,83 @@ in
   # Nixpkgs設定
   nixpkgs.config.allowUnfree = true;
 
+  # Homebrew設定
+  homebrew = {
+    enable = true;
+    onActivation = {
+      autoUpdate = true;
+      upgrade = true;
+      cleanup = "zap";
+    };
+    brews = [
+      # 開発ツール
+      "go" # Goプログラミング言語
+      "nvm" # Node.jsバージョンマネージャー
+
+      # CLIツール
+      "jq" # JSONプロセッサ
+      "yq" # YAMLプロセッサ
+      "yamllint" # YAMLリンター
+      "mas" # Mac App Store CLI
+    ];
+    casks = [
+      # 開発ツール
+      "cursor" # AIパワードエディタ
+      "copilot-for-xcode" # GitHub Copilot for Xcode
+      "graphql-playground" # GraphQLクライアント
+      "altair-graphql-client" # GraphQLクライアント
+      "xquartz" # X11サーバー
+
+      # 生産性ツール
+      "obsidian" # ナレッジマネジメント
+      "claude" # Claude AIアシスタント
+
+      # クリエイティブツール
+      "adobe-creative-cloud" # Adobe Creative Cloud
+
+      # コミュニケーション
+      "discord" # Discordチャット
+
+      # ユーティリティ
+      "vnc-viewer" # VNCクライアント
+      "1password"
+      "vlc"
+    ];
+    masApps = {
+      # Apple製アプリ
+      "GarageBand" = 682658836;
+      "iMovie" = 408981434;
+      "Keynote" = 409183694;
+      "Numbers" = 409203825;
+      "Pages" = 409201541;
+
+      # Microsoft Office
+      "Microsoft Excel" = 462058435;
+      "Microsoft OneNote" = 784801555;
+      "Microsoft Outlook" = 985367838;
+      "Microsoft PowerPoint" = 462062816;
+      "Microsoft Word" = 462054704;
+      "OneDrive" = 823766827;
+
+      # 生産性ツール
+      "Goodnotes" = 1444383602;
+      "Spark" = 1176895641;
+
+      # コミュニケーション
+      "LINE" = 539883307;
+      "Slack for Desktop" = 803453959;
+
+      # 開発ツール
+      "Xcode" = 497799835;
+
+      # ユーティリティ
+      "Brother iPrint&Scan" = 1193539993;
+      "CommentScreen" = 1450950860;
+      "RunCat" = 1429033973;
+      "WireGuard" = 1451685025;
+    };
+  };
+
   # Home Manager設定
   home-manager = {
     useGlobalPkgs = true;

--- a/systems/darwin/configurations/macmini/default.nix
+++ b/systems/darwin/configurations/macmini/default.nix
@@ -1,0 +1,60 @@
+/*
+  Darwin設定 - macmini
+
+  Mac Mini用のmacOSシステム設定を定義します。
+  MacBookと比較して以下の違いがあります：
+  - WireGuardは不要
+  - Homebrewパッケージは最小限（Claude, Google Chrome, Xcode のみ）
+*/
+{
+  config,
+  pkgs,
+  lib,
+  inputs,
+  ...
+}:
+
+let
+  cfg = import ../../../../shared/config.nix;
+  username = cfg.users.darwin.username;
+in
+{
+  imports = [
+    # 基本モジュール
+    ../../modules/base.nix
+    ../../modules/optimise.nix
+    # WireGuardは不要
+
+    # 外部モジュール
+    inputs.home-manager.darwinModules.home-manager
+    inputs.sops-nix.darwinModules.sops
+  ];
+
+  # Nixpkgs設定
+  nixpkgs.config.allowUnfree = true;
+
+  # Homebrew設定（最小限）
+  homebrew = {
+    enable = true;
+    onActivation = {
+      autoUpdate = true;
+      upgrade = true;
+      cleanup = "zap";
+    };
+    casks = [
+      "claude" # Claude AIアシスタント
+      "google-chrome" # Webブラウザ
+    ];
+    masApps = {
+      "Xcode" = 497799835;
+    };
+  };
+
+  # Home Manager設定
+  home-manager = {
+    useGlobalPkgs = true;
+    useUserPackages = true;
+    extraSpecialArgs = { inherit inputs; };
+    users.${username} = import ../../../../home/profiles/shinbunbun;
+  };
+}

--- a/systems/darwin/modules/base.nix
+++ b/systems/darwin/modules/base.nix
@@ -5,7 +5,6 @@
   - システムバージョン設定
   - Nix設定（sandbox、trusted-users）
   - Touch IDを使用したsudo認証
-  - Homebrew設定
 */
 {
   config,
@@ -49,80 +48,4 @@ in
   '';
 
   security.pam.services.sudo_local.touchIdAuth = true;
-
-  homebrew = {
-    enable = true;
-    onActivation = {
-      autoUpdate = true;
-      upgrade = true;
-      cleanup = "zap";
-    };
-    brews = [
-      # 開発ツール
-      "go" # Goプログラミング言語
-      "nvm" # Node.jsバージョンマネージャー
-
-      # CLIツール
-      "jq" # JSONプロセッサ
-      "yq" # YAMLプロセッサ
-      "yamllint" # YAMLリンター
-      "mas" # Mac App Store CLI
-    ];
-    casks = [
-      # 開発ツール
-      "cursor" # AIパワードエディタ
-      "copilot-for-xcode" # GitHub Copilot for Xcode
-      "graphql-playground" # GraphQLクライアント
-      "altair-graphql-client" # GraphQLクライアント
-      "xquartz" # X11サーバー
-
-      # 生産性ツール
-      "obsidian" # ナレッジマネジメント
-      "claude" # Claude AIアシスタント
-
-      # クリエイティブツール
-      "adobe-creative-cloud" # Adobe Creative Cloud
-
-      # コミュニケーション
-      "discord" # Discordチャット
-
-      # ユーティリティ
-      "vnc-viewer" # VNCクライアント
-      "1password"
-      "vlc"
-    ];
-    masApps = {
-      # Apple製アプリ
-      "GarageBand" = 682658836;
-      "iMovie" = 408981434;
-      "Keynote" = 409183694;
-      "Numbers" = 409203825;
-      "Pages" = 409201541;
-
-      # Microsoft Office
-      "Microsoft Excel" = 462058435;
-      "Microsoft OneNote" = 784801555;
-      "Microsoft Outlook" = 985367838;
-      "Microsoft PowerPoint" = 462062816;
-      "Microsoft Word" = 462054704;
-      "OneDrive" = 823766827;
-
-      # 生産性ツール
-      "Goodnotes" = 1444383602;
-      "Spark" = 1176895641;
-
-      # コミュニケーション
-      "LINE" = 539883307;
-      "Slack for Desktop" = 803453959;
-
-      # 開発ツール
-      "Xcode" = 497799835;
-
-      # ユーティリティ
-      "Brother iPrint&Scan" = 1193539993;
-      "CommentScreen" = 1450950860;
-      "RunCat" = 1429033973;
-      "WireGuard" = 1451685025;
-    };
-  };
 }


### PR DESCRIPTION
- base.nixからHomebrew設定を分離し、各マシン設定に移動
- macmini/default.nixを新規作成（最小限のHomebrew: Claude, Chrome, Xcode）
- flake.nixにmacmini darwinConfigurationを追加