### PR TITLE
deploy-rsのchecksをx86_64-linuxに限定

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -232,7 +232,7 @@
         };
       };
 
-      # deploy-rs checks
-      checks = builtins.mapAttrs (system: deployLib: deployLib.deployChecks self.deploy) deploy-rs.lib;
+      # deploy-rs checks（デプロイ先がx86_64-linuxのみのため、該当システムに限定）
+      checks."x86_64-linux" = deploy-rs.lib.x86_64-linux.deployChecks self.deploy;
     };
 }


### PR DESCRIPTION
builtins.mapAttrsで全システム分のchecksを生成していたため、
aarch64-darwinでnix flake checkを実行するとx86_64-linux用の
derivationをビルドしようとして失敗していた。
デプロイ先はx86_64-linuxのみのため、checksも該当システムに限定する。

Closes #360

https://claude.ai/code/session_01YcUGEBkRu7wqwnbQJ3UHbY