### PR TITLE
macbookビルドのwarning2件を修正

### DIFF
--- a/home/modules/shell/shell-tools.nix
+++ b/home/modules/shell/shell-tools.nix
@@ -9,11 +9,12 @@
 
   starshipはステータス表示と時刻表示が有効化されています。
 */
-{ pkgs, ... }:
+{ pkgs, config, ... }:
 {
   # zsh config
   programs.zsh = {
     enable = true;
+    dotDir = "${config.xdg.configHome}/zsh";
     enableCompletion = true;
     autosuggestion.enable = true;
     plugins = [

--- a/home/profiles/bunbun/default.nix
+++ b/home/profiles/bunbun/default.nix
@@ -40,7 +40,7 @@ in
     # Nix開発ツール
     nil
     nixd
-    nixfmt-rfc-style
+    nixfmt
   ];
 
   # Home Managerの有効化

--- a/home/profiles/shinbunbun/default.nix
+++ b/home/profiles/shinbunbun/default.nix
@@ -46,7 +46,7 @@ in
     # Nix開発ツール
     nil
     nixd
-    nixfmt-rfc-style
+    nixfmt
 
     # macOS専用アプリケーション
     nerd-fonts.fira-code


### PR DESCRIPTION
- programs.zsh.dotDir を追加してXDG準拠に
- nixfmt-rfc-style を nixfmt にリネーム（非推奨警告対応）