### PR TITLE
claude-code-nix flake を導入し、NixOS で Claude Code を Nix 管理に移行

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -23,6 +23,27 @@
         "type": "github"
       }
     },
+    "claude-code": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1771632347,
+        "narHash": "sha256-kNm0YX9RUwf7GZaWQu2F71ccm4OUMz0xFkXn6mGPfps=",
+        "owner": "sadjow",
+        "repo": "claude-code-nix",
+        "rev": "ec90f84b2ea21f6d2272e00d1becbc13030d1895",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sadjow",
+        "repo": "claude-code-nix",
+        "type": "github"
+      }
+    },
     "crane": {
       "locked": {
         "lastModified": 1751562746,
@@ -135,7 +156,7 @@
     },
     "flake-utils": {
       "inputs": {
-        "systems": "systems_2"
+        "systems": "systems"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -190,6 +211,24 @@
     "flake-utils_4": {
       "inputs": {
         "systems": "systems_5"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_5": {
+      "inputs": {
+        "systems": "systems_6"
       },
       "locked": {
         "lastModified": 1681202837,
@@ -268,7 +307,7 @@
     },
     "nixos-observability": {
       "inputs": {
-        "flake-utils": "flake-utils_2",
+        "flake-utils": "flake-utils_3",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -371,7 +410,7 @@
     },
     "peer-issuer": {
       "inputs": {
-        "flake-utils": "flake-utils_3",
+        "flake-utils": "flake-utils_4",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -393,9 +432,10 @@
     "root": {
       "inputs": {
         "attic": "attic",
+        "claude-code": "claude-code",
         "deploy-rs": "deploy-rs",
         "devshell": "devshell",
-        "flake-utils": "flake-utils",
+        "flake-utils": "flake-utils_2",
         "home-manager": "home-manager",
         "nix-darwin": "nix-darwin",
         "nixos-observability": "nixos-observability",
@@ -501,9 +541,24 @@
         "type": "github"
       }
     },
+    "systems_6": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
     "utils": {
       "inputs": {
-        "systems": "systems"
+        "systems": "systems_2"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -521,7 +576,7 @@
     },
     "vscode-server": {
       "inputs": {
-        "flake-utils": "flake-utils_4",
+        "flake-utils": "flake-utils_5",
         "nixpkgs": [
           "nixpkgs"
         ]

--- a/flake.nix
+++ b/flake.nix
@@ -82,6 +82,12 @@
       url = "github:shinbunbun/peer-issuer";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    # claude-code: Claude Code CLIツール（Nix native binary）
+    claude-code = {
+      url = "github:sadjow/claude-code-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =
@@ -99,6 +105,7 @@
       deploy-rs,
       attic,
       peer-issuer,
+      claude-code,
       ...
     }@inputs:
     let

--- a/home/modules/development/ai-tools.nix
+++ b/home/modules/development/ai-tools.nix
@@ -10,6 +10,7 @@
 { pkgs, ... }:
 {
   home.packages = [
+    pkgs.claude-code
   ];
 
   home.file.".claude/CLAUDE.md" = {

--- a/systems/nixos/configurations/homeMachine/default.nix
+++ b/systems/nixos/configurations/homeMachine/default.nix
@@ -66,6 +66,9 @@ in
 
   # Nixpkgs設定
   nixpkgs.config.allowUnfree = true;
+  nixpkgs.overlays = [
+    inputs.claude-code.overlays.default
+  ];
 
   # RouterOSバックアップ設定
   services.routerosBackup = {


### PR DESCRIPTION
- flake inputs に claude-code-nix を追加
- homeMachine に overlay を適用
- ai-tools.nix に pkgs.claude-code を追加