### PR TITLE
macminiのスリープを無効化（ヘッドレス運用対応）

### DIFF
--- a/systems/darwin/configurations/macmini/default.nix
+++ b/systems/darwin/configurations/macmini/default.nix
@@ -39,6 +39,11 @@ in
   networking.computerName = cfg.networking.hosts.macmini.hostname;
   networking.localHostName = cfg.networking.hosts.macmini.hostname;
 
+  # 電源管理設定（ヘッドレス運用のためスリープ無効化）
+  power.sleep.computer = "never";
+  power.sleep.display = "never";
+  power.sleep.harddisk = "never";
+
   # SSH（Remote Login）有効化
   services.openssh.enable = true;
 


### PR DESCRIPTION
- macminiの `power.sleep` 設定で computer / display / harddisk をすべて `"never"` に設定
- ヘッドレス運用時のスリープによるサービス停止を防止