### PR TITLE
ログローテーション後にmacos-log-streamデーモンを再起動

### DIFF
--- a/systems/darwin/modules/fluent-bit.nix
+++ b/systems/darwin/modules/fluent-bit.nix
@@ -78,6 +78,8 @@ let
       TIMESTAMP=$(/bin/date "+%Y%m%d-%H%M%S")
       mv "$LOG_FILE" "$ROTATE_DIR/macos-unified.$TIMESTAMP.log"
       touch "$LOG_FILE"
+      # mvでファイルが移動すると、log streamプロセスのfdが旧ファイルを指し続けるため再起動が必要
+      launchctl kickstart -k system/com.shinbunbun.macos-log-stream
     fi
 
     # 古いアーカイブを削除


### PR DESCRIPTION
毎朝3:00のログローテーションでmvによりログファイルを移動した後、
log streamプロセスのファイルディスクリプタが旧ファイルを指し続け、
Fluent Bitがログを受信できなくなる問題を修正。
ローテーション後にlaunchctl kickstartでデーモンを再起動し、
新しいログファイルへの書き込みを継続させる。