### PR TITLE
KSOPS（Kustomize + SOPS）対応を追加

### DIFF
--- a/shared/config.nix
+++ b/shared/config.nix
@@ -404,6 +404,15 @@ let
       helmChartVersion =
         assertType "argocd.helmChartVersion" "9.4.3" builtins.isString
           "Must be a string";
+      # KSOPS（Kustomize + SOPS）プラグインのイメージバージョン
+      ksopsImage =
+        assertType "argocd.ksopsImage" "viaductoss/ksops:v4.3.2" builtins.isString
+          "Must be a string";
+      # k8s専用Age公開鍵（Secret暗号化用、秘密鍵はArgoCD repo-serverのみ保持）
+      k8sAgePublicKey =
+        assertType "argocd.k8sAgePublicKey" "age1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+          builtins.isString
+          "Must be a string";
     };
 
     # GitHub Container Registry設定


### PR DESCRIPTION
## Summary
- `config.nix`: `ksopsImage` と `k8sAgePublicKey` 設定値を追加（ハードコード回避）
- `argocd.nix`: repo-serverにKSOPSプラグイン用initContainer、Volume、環境変数を追加
- `argocd.nix`: `kustomize.buildOptions` でKSOPS execプラグインを有効化
- `argocd.nix`: k8s専用Age秘密鍵の`sops.secrets`定義とKubernetes Secret投入処理を追加