### PR TITLE
k3s-registriesサービスにk3s再起動ロジックを追加

### DIFF
--- a/systems/nixos/modules/k3s.nix
+++ b/systems/nixos/modules/k3s.nix
@@ -77,7 +77,10 @@ in
       after = [ "sops-nix.service" ];
       wantedBy = [ "multi-user.target" ];
 
-      path = [ pkgs.coreutils ];
+      path = [
+        pkgs.coreutils
+        pkgs.systemd
+      ];
 
       serviceConfig = {
         Type = "oneshot";
@@ -107,6 +110,11 @@ in
           EOF
 
           chmod 0600 /etc/rancher/k3s/registries.yaml
+
+          # k3sが既に稼働中の場合、registries.yamlの変更を反映するため再起動
+          if systemctl is-active --quiet k3s.service; then
+            systemctl restart k3s.service
+          fi
         '';
     };
 


### PR DESCRIPTION
- k3s-registriesのscript末尾に、k3sが稼働中の場合に再起動するロジックを追加
- `path`に`pkgs.systemd`を追加
- k3s起動後にregistries.yamlが生成された場合でも認証情報が反映されるようになる