### PR TITLE
_github-runnerユーザーをNix allowed-users/trusted-usersに追加

### DIFF
--- a/systems/darwin/modules/base.nix
+++ b/systems/darwin/modules/base.nix
@@ -24,8 +24,14 @@ in
     # macOS推奨: Fixed-output derivations（npm依存関係など）をサンドボックスから除外
     # これによりDNS解決とネットワークアクセスが正常に動作する
     sandbox = "relaxed";
-    trusted-users = [ "@admin" ];
-    allowed-users = [ "@admin" ];
+    trusted-users = [
+      "@admin"
+      "_github-runner"
+    ];
+    allowed-users = [
+      "@admin"
+      "_github-runner"
+    ];
 
     # Attic バイナリキャッシュ設定（プライベート）
     substituters = [


### PR DESCRIPTION
## Summary

- `nix.settings.trusted-users`と`nix.settings.allowed-users`に`_github-runner`ユーザーを追加
- Mac miniのself-hosted GitHub Actions runnerがNix daemonに接続できるようにするための変更
- 現状`allowed-users = [ "@admin" ]`のみのため、`_github-runner`ユーザーが`nix build`実行時に"Nix daemon disconnected unexpectedly"エラーになっていた