### PR TITLE
k3sのnode-ipをIPv4に固定してCPU使用率問題を修正

### DIFF
--- a/shared/config.nix
+++ b/shared/config.nix
@@ -182,6 +182,7 @@ let
         extraFlags = [
           "--flannel-backend=vxlan"
           "--write-kubeconfig-mode=0644"
+          "--node-ip=192.168.1.4"
         ];
       };
 


### PR DESCRIPTION
IPv6 SLAACの一時アドレスローテーションにより、k3sが「NodeIPs changed」を 頻繁に検知し、etcd書き込み→コントローラ再調整のループでCPU使用率が約90%に
達していた。--node-ip=192.168.1.4を指定してIPv6アドレスの変動を無視させる。