### PR TITLE
k3sのGOMAXPROCSを制限してCPU使用率問題を修正

### DIFF
--- a/shared/config.nix
+++ b/shared/config.nix
@@ -184,6 +184,9 @@ let
           "--write-kubeconfig-mode=0644"
           "--node-ip=192.168.1.4"
         ];
+
+        # GoランタイムのMAXPROCS設定（CPUコア数が多い環境でスケジューラの空回りを防止）
+        goMaxProcs = assertType "k3s.desktop.goMaxProcs" 4 builtins.isInt "Must be an integer";
       };
 
       # 将来のhomeMachine用設定（現時点では無効）

--- a/systems/nixos/modules/k3s.nix
+++ b/systems/nixos/modules/k3s.nix
@@ -53,6 +53,7 @@ let
   role = k3sConfig.role or "server";
   clusterInit = k3sConfig.clusterInit or false;
   extraFlags = k3sConfig.extraFlags or [ ];
+  goMaxProcs = k3sConfig.goMaxProcs or null;
 in
 {
   config = lib.mkIf enable {
@@ -66,6 +67,11 @@ in
 
       # 追加フラグ
       extraFlags = lib.strings.concatStringsSep " " extraFlags;
+    };
+
+    # GoランタイムのMAXPROCS制限（CPUコア数が多い環境でスケジューラの空回りを防止）
+    systemd.services.k3s.environment = lib.mkIf (goMaxProcs != null) {
+      GOMAXPROCS = toString goMaxProcs;
     };
 
     # ghcr.io認証用のregistries.yamlを動的生成するsystemdサービス


### PR DESCRIPTION
## 概要

24コア環境でk3s-serverプロセスが常時約90%のCPUを消費していた問題を修正。

## 原因

`perf top`でプロファイリングした結果、CPUの上位をGoランタイムスケジューラの関数が占めていた：
- `runtime.stealWork` (4%)
- `runtime.unlock2` / `runtime.lock2` (3-5%)
- `runtime.selectgo` (2-3%)
- `runtime.findRunnable` (1.4%)

24コアに対してGOMAXPROCS=24（デフォルト）で動作しており、実ワークロードが軽量（Pod合計約15m）にも関わらず、Goスケジューラが24スレッドでワーク・スティーリングを繰り返して空回りしていた。

## 修正内容

- `shared/config.nix`: `goMaxProcs = 4` を追加
- `systems/nixos/modules/k3s.nix`: `systemd.services.k3s.environment.GOMAXPROCS` を設定