### PR TITLE
Loki MCPサーバーのNixパッケージを追加

### DIFF
--- a/home/modules/development/ai-tools.nix
+++ b/home/modules/development/ai-tools.nix
@@ -3,6 +3,7 @@
 
   このモジュールはAI関連のツールを提供します：
   - claude-code: Claudeの公式CLIツール
+  - loki-mcp-server: Loki MCPサーバー（Claude CodeからLokiへのLogQLクエリ実行用）
 
   Claudeのグローバル設定ファイル（CLAUDE.md）も配置し、
   日本語での応答をデフォルト設定としています。
@@ -13,6 +14,7 @@
     with pkgs;
     lib.optionals stdenv.isLinux [
       claude-code
+      loki-mcp-server
     ];
 
   home.file.".claude/CLAUDE.md" = {

--- a/systems/nixos/configurations/homeMachine/default.nix
+++ b/systems/nixos/configurations/homeMachine/default.nix
@@ -68,6 +68,7 @@ in
   nixpkgs.config.allowUnfree = true;
   nixpkgs.overlays = [
     inputs.claude-code.overlays.default
+    (import ../../overlays/loki-mcp.nix)
   ];
 
   # RouterOSバックアップ設定

--- a/systems/nixos/overlays/loki-mcp.nix
+++ b/systems/nixos/overlays/loki-mcp.nix
@@ -1,0 +1,36 @@
+/*
+  Loki MCP Server オーバーレイ
+
+  Grafana公式のLoki MCPサーバーをビルドします。
+  Claude CodeからLokiへのLogQLクエリ実行を可能にします。
+  https://github.com/grafana/loki-mcp
+*/
+final: prev: {
+  loki-mcp-server = prev.buildGoModule rec {
+    pname = "loki-mcp-server";
+    version = "0.6.0";
+
+    src = prev.fetchFromGitHub {
+      owner = "grafana";
+      repo = "loki-mcp";
+      rev = "v${version}";
+      hash = "sha256-rRnKsE/jiOcvLZ8keN+i5X3nw8Hyx4wdq6w6EpAPjZ0=";
+    };
+
+    vendorHash = "sha256-xu9/BBKiUMNUhQQZCaifCoYtu0fkXqyx2aZUGQh2hGQ=";
+
+    subPackages = [ "cmd/server" ];
+
+    # サブパッケージ名 "server" → "loki-mcp-server" にリネーム
+    postInstall = ''
+      mv $out/bin/server $out/bin/loki-mcp-server
+    '';
+
+    meta = with prev.lib; {
+      description = "MCP (Model Context Protocol) Server for Grafana Loki";
+      homepage = "https://github.com/grafana/loki-mcp";
+      license = licenses.asl20;
+      mainProgram = "loki-mcp-server";
+    };
+  };
+}


### PR DESCRIPTION
grafana/loki-mcp v0.6.0をoverlayとしてパッケージ化し、
ai-tools.nixのhome.packagesに追加。
Claude CodeからLokiへのLogQLクエリ実行を可能にする。