### PR TITLE
mcp-grafanaを全プラットフォームでインストール可能にする

### DIFF
--- a/home/modules/development/ai-tools.nix
+++ b/home/modules/development/ai-tools.nix
@@ -12,9 +12,11 @@
 {
   home.packages =
     with pkgs;
-    lib.optionals stdenv.isLinux [
-      claude-code
+    [
       mcp-grafana
+    ]
+    ++ lib.optionals stdenv.isLinux [
+      claude-code
     ];
 
   home.file.".claude/CLAUDE.md" = {


### PR DESCRIPTION
mcp-grafanaがisLinuxガード内にあったため、macOS（Mac mini等）で
インストールされなかった。claude-codeのみLinux限定に残し、
mcp-grafanaは全プラットフォームで利用可能にする。