### PR TITLE
Auto-update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -251,11 +251,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772164835,
-        "narHash": "sha256-zRcwrZDeBfYipqv/7K7TqsfPb87LFU6b7JhoNUGSnvQ=",
+        "lastModified": 1772218752,
+        "narHash": "sha256-G8nArvOTZXU8DRvrzAdz3Elcj6kA/vMtvY9mrGLATtA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2a39b0828bbffce0d73769a61e46e780488d098b",
+        "rev": "f3a30376bb9eb2f6f61816be7d6ed954b6d2a3b9",
         "type": "github"
       },
       "original": {
@@ -333,11 +333,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772029314,
-        "narHash": "sha256-IFu9vQsqi9NoqooQ3RCNHTK+KRCX7GeVE8WQou/P1+c=",
+        "lastModified": 1772248894,
+        "narHash": "sha256-3g4OMedQAx9WVaOuKHIn0EAcSMgDBN8gNxG/TDX++Po=",
         "owner": "shinbunbun",
         "repo": "nixos-observability-config",
-        "rev": "86d028062f803a1cd1d79af67d549d41dca97c82",
+        "rev": "7dd2b920504ab511cd0045a1db34de5bdf8077a9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This PR updates flake.lock with the latest input updates via `nix flake update`.

Please review and merge if everything looks OK.