### PR TITLE
Mosh（Mobile Shell）を追加

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -217,6 +217,7 @@
           peer-issuer = ./systems/nixos/modules/services/peer-issuer.nix;
           deploy-user = ./systems/nixos/modules/services/deploy-user.nix;
           argocd = ./systems/nixos/modules/services/argocd.nix;
+          mosh = ./systems/nixos/modules/services/mosh.nix;
         };
       };
 

--- a/systems/darwin/configurations/macmini/default.nix
+++ b/systems/darwin/configurations/macmini/default.nix
@@ -56,6 +56,11 @@ in
     KbdInteractiveAuthentication no
   '';
 
+  # Mosh（Mobile Shell）パッケージ
+  environment.systemPackages = [
+    pkgs.mosh
+  ];
+
   # SSH公開鍵認証（nix-darwinのAuthorizedKeysCommand経由で配置）
   users.users.${username}.openssh.authorizedKeys.keys = [
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPsh7m83p/bIrnzDVYUTzNfw9OAgVH1nu80Qg2TElgVL"

--- a/systems/nixos/configurations/homeMachine/default.nix
+++ b/systems/nixos/configurations/homeMachine/default.nix
@@ -34,6 +34,7 @@ in
     ../../modules/wireguard.nix
 
     # サービスモジュール
+    ../../modules/services/mosh.nix
     ../../modules/services/services.nix
     # ../../modules/services/monitoring.nix          # nixos-observability に移行
     # ../../modules/services/alertmanager.nix        # nixos-observability に移行

--- a/systems/nixos/modules/services/mosh.nix
+++ b/systems/nixos/modules/services/mosh.nix
@@ -1,0 +1,12 @@
+/*
+  Mosh（Mobile Shell）設定モジュール
+
+  このモジュールはMoshの設定を行います：
+  - Moshパッケージのインストール
+  - UDPファイアウォールポートの自動開放（60000-61000）
+  - utempterサポート（ユーザーセッション追跡）
+*/
+{ ... }:
+{
+  programs.mosh.enable = true;
+}


### PR DESCRIPTION
## 概要
- NixOS用Moshモジュール（`programs.mosh.enable = true`）を新規作成（パッケージ・ファイアウォール・utempter自動設定）
- homeMachineにMoshモジュールを追加
- macminiに`pkgs.mosh`パッケージを追加
- `flake.nix`の`nixosModules.services`にMoshモジュールをexport（dotfiles-privateのnixos-desktopから利用可能に）

## 関連Issue
- Closes #421