### PR TITLE
Home Manager経由でtmuxを導入

### DIFF
--- a/home/modules/shell/tmux.nix
+++ b/home/modules/shell/tmux.nix
@@ -1,0 +1,62 @@
+/*
+  tmux設定モジュール
+
+  ターミナルマルチプレクサtmuxの設定を提供します：
+  - マウス操作対応（ペイン選択・リサイズ・スクロール）
+  - 直感的なキーバインド（| で縦分割、- で横分割）
+  - システムクリップボード連携（tmux-yank）
+  - 基本設定の改善（tmux-sensible）
+
+  使い方:
+    tmux           - 新しいセッションを開始
+    tmux attach    - 既存セッションに接続
+    prefix + |     - 縦分割
+    prefix + -     - 横分割
+    prefix + r     - 設定リロード
+*/
+{ pkgs, ... }:
+{
+  programs.tmux = {
+    enable = true;
+
+    # マウスでペイン選択・リサイズ・スクロール可能
+    mouse = true;
+
+    # コピーモードで矢印キーベースの操作
+    keyMode = "emacs";
+
+    # 24時間表示
+    clock24 = true;
+
+    # スクロールバック行数
+    historyLimit = 50000;
+
+    # ウィンドウ/ペイン番号を1始まりに（キーボード配置に合わせる）
+    baseIndex = 1;
+
+    # Escキーの遅延を短縮（ms）
+    escapeTime = 10;
+
+    # 256色対応
+    terminal = "tmux-256color";
+
+    # プラグイン
+    plugins = with pkgs.tmuxPlugins; [
+      sensible # 基本的なデフォルト設定の改善
+      yank # システムクリップボードへのコピー対応
+    ];
+
+    # 追加キーバインド
+    extraConfig = ''
+      # 直感的なペイン分割
+      bind | split-window -h -c "#{pane_current_path}"
+      bind - split-window -v -c "#{pane_current_path}"
+
+      # 設定リロード
+      bind r source-file ~/.config/tmux/tmux.conf \; display-message "設定をリロードしました"
+
+      # ペイン番号も1始まりに
+      setw -g pane-base-index 1
+    '';
+  };
+}

--- a/home/profiles/bunbun/default.nix
+++ b/home/profiles/bunbun/default.nix
@@ -20,6 +20,7 @@ in
     # シェルツール
     ../../modules/shell/shell-tools.nix
     ../../modules/shell/version-control.nix
+    ../../modules/shell/tmux.nix
 
     # セキュリティツール
     ../../modules/security/security-tools.nix

--- a/home/profiles/shinbunbun/default.nix
+++ b/home/profiles/shinbunbun/default.nix
@@ -26,6 +26,7 @@ in
     # シェルツール
     ../../modules/shell/shell-tools.nix
     ../../modules/shell/version-control.nix
+    ../../modules/shell/tmux.nix
 
     # セキュリティツール
     ../../modules/security/security-tools.nix


### PR DESCRIPTION
## 概要
- tmux設定モジュール（`home/modules/shell/tmux.nix`）を新規作成
- bunbun/shinbunbun両プロファイルからインポートし、homeMachine・nixos-desktop・macminiの3台に適用
- マウス操作、直感的なキーバインド（`|` で縦分割、`-` で横分割）、クリップボード連携（tmux-yank）等を設定

## 関連Issue
- Closes #423