### PR TITLE
peer-issuer WireGuard MTUを1280から1420に引き上げ

### DIFF
--- a/shared/config.nix
+++ b/shared/config.nix
@@ -653,7 +653,7 @@ let
       routerWgInterface =
         assertType "peerIssuer.routerWgInterface" "wg-home" builtins.isString
           "Must be a string";
-      wgMTU = assertType "peerIssuer.wgMTU" 1280 (
+      wgMTU = assertType "peerIssuer.wgMTU" 1420 (
         n: builtins.isInt n && n > 0
       ) "Must be a positive integer";
       wgKeepalive = assertType "peerIssuer.wgKeepalive" 25 (


### PR DESCRIPTION
## 概要
- peer-issuer の WireGuard MTU を 1280（IPv6最小値）から 1420（1500 - 80 WireGuard overhead）に変更
- CI環境（GitHub Actions）での Attic バイナリキャッシュ push 速度改善が目的
- ペイロード効率が 1220 → 1360 バイト（約11%改善）に加え、パケット数減少によるオーバーヘッド削減

## 影響範囲
- peer-issuer API経由のCIリースのみ
- 静的WireGuardクライアント（NixOS `wg0`, macOS `wg-home`）は `wireguard-helper.nix` で別管理されており影響なし
- IPプールも別（CI: `10.66.66.64/26`, 静的: `10.100.0.0/24`）

## 関連Issue
- Refs: shinbunbun/nix-ci-workflows#333