### PR TITLE
Calendar BotのTunnel向き先をk8s(Traefik)に変更

### DIFF
--- a/systems/nixos/modules/services/desktop-cloudflare-tunnel.nix
+++ b/systems/nixos/modules/services/desktop-cloudflare-tunnel.nix
@@ -65,7 +65,7 @@ in
 
           # Google Calendar Bot - Zero Trust Accessで認証必要
           "${tunnelConfig.calendarBot.domain}" = {
-            service = "http://localhost:8080";
+            service = "http://localhost:80"; # Traefik (k8s)
             originRequest = {
               noTLSVerify = true;
               httpHostHeader = "${tunnelConfig.calendarBot.domain}";

--- a/terraform/access_policies.tf
+++ b/terraform/access_policies.tf
@@ -136,6 +136,24 @@ resource "cloudflare_zero_trust_access_application" "opensearch_dashboards" {
   }]
 }
 
+# Google Calendar Bot - 認証必須
+resource "cloudflare_zero_trust_access_application" "calendar_bot" {
+  account_id                = var.cloudflare_account_id
+  name                      = "Google Calendar Bot"
+  domain                    = local.desktop_services.calendar_bot
+  type                      = "self_hosted"
+  session_duration          = "24h"
+  auto_redirect_to_identity = true
+  allowed_idps              = [var.identity_provider_id]
+  enable_binding_cookie     = false
+  options_preflight_bypass  = false
+
+  policies = [{
+    id         = cloudflare_zero_trust_access_policy.oidc_groups_allow.id
+    precedence = 1
+  }]
+}
+
 
 # ========================================
 # CloudFlare Zero Trust Access Policies


### PR DESCRIPTION
## 概要
- Cloudflare TunnelのCalendar Bot向き先を`localhost:8080`(NixOSサービス)から`localhost:80`(Traefik/k8s)に変更
- Cloudflare Zero Trust Access Policyを追加し、Authentik経由の認証を必須化
- k8s-apps側のIngressRoute追加と合わせて、NixOS→k8s移行の準備