### PR TITLE
Calendar Bot k8s移行: Cloudflare Tunnel/Access設定 + 認証エラー修正

### DIFF
--- a/terraform/authentik_groups.tf
+++ b/terraform/authentik_groups.tf
@@ -8,7 +8,7 @@
 resource "authentik_group" "cloudflare_access" {
   name         = "Cloudflare Access"
   is_superuser = false
-  users        = [authentik_user.hina.id]
+  users        = [authentik_user.hina.id, data.authentik_user.shinbunbun.id]
 }
 
 resource "authentik_group" "obsidian_users" {

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -11,6 +11,7 @@ output "access_application_ids" {
     desktop_ttyd          = cloudflare_zero_trust_access_application.desktop_ttyd.id
     opensearch_dashboards = cloudflare_zero_trust_access_application.opensearch_dashboards.id
     argocd                = cloudflare_zero_trust_access_application.argocd.id
+    calendar_bot          = cloudflare_zero_trust_access_application.calendar_bot.id
   }
 }
 


### PR DESCRIPTION
## 概要
- Calendar BotのCloudflare Tunnel向き先をTraefikに変更（k8s移行対応）
- Calendar Bot用のCloudflare Access Policyを追加
- `cloudflare_access`グループに`shinbunbun`ユーザーを追加（全サービス認証エラーの修正）
- `calendar_bot`のAccess Application IDをoutputに追加

## 背景
`terraform apply`実行時にAuthentikの`cloudflare_access`グループメンバーシップがTerraform定義にリセットされ、手動追加されていた`shinbunbun`ユーザーが除外された。これにより、Calendar Botだけでなく、Cockpit・ttyd等**全てのCloudflare Accessサービスで認証が失敗**していた。

## 変更ファイル
- `nix/modules/services/desktop-cloudflare-tunnel.nix` - Calendar BotのTunnel向き先変更
- `terraform/access_policies.tf` - Calendar Bot用Access Application/Policy追加
- `terraform/authentik_groups.tf` - `cloudflare_access`グループに`shinbunbun`追加
- `terraform/outputs.tf` - `calendar_bot`のApplication IDをoutputに追加