### PR TITLE
WireGuard MTUを1392に最適化

### DIFF
--- a/shared/config.nix
+++ b/shared/config.nix
@@ -653,7 +653,7 @@ let
       routerWgInterface =
         assertType "peerIssuer.routerWgInterface" "wg-home" builtins.isString
           "Must be a string";
-      wgMTU = assertType "peerIssuer.wgMTU" 1420 (
+      wgMTU = assertType "peerIssuer.wgMTU" 1392 (
         n: builtins.isInt n && n > 0
       ) "Must be a positive integer";
       wgKeepalive = assertType "peerIssuer.wgKeepalive" 25 (


### PR DESCRIPTION
## 概要
- `peerIssuer.wgMTU` を 1420 → 1392 に変更（PMTU実測値に基づく最適化）
- v6プラス固定IP(MAP-E方式)のオーバーヘッド(+40B IPv6ヘッダ)により、WG MTU 1420ではPath MTU超過が発生していたのを修正