### PR TITLE
ArgoCD Web Terminal（exec）機能を有効化

### DIFF
--- a/systems/nixos/modules/services/argocd.nix
+++ b/systems/nixos/modules/services/argocd.nix
@@ -59,6 +59,10 @@ let
         url = "https://${argocdCfg.domain}";
         # KSOPS（Kustomize + SOPS）プラグインを有効化
         "kustomize.buildOptions" = "--enable-alpha-plugins --enable-exec";
+        # Web Terminal（exec）機能を有効化
+        "exec.enabled" = "true";
+        # 利用可能なシェルの優先順位（Linux Podのみ想定）
+        "exec.shells" = "bash,sh";
         # Dex を無効化（外部 OIDC を直接使用）
         "dex.config" = "";
         # OIDC 設定
@@ -86,6 +90,7 @@ let
           p, role:app-manager, applications, sync, */*, allow
           p, role:app-manager, applications, action/*, */*, allow
           p, role:app-manager, logs, get, */*, allow
+          p, role:app-manager, exec, create, */*, allow
           p, role:app-manager, projects, get, *, allow
           g, ArgoCD Admins, role:admin
           g, ArgoCD Users, role:app-manager


### PR DESCRIPTION
## 概要
- ArgoCD ConfigMap（`configs.cm`）に `exec.enabled = "true"` と `exec.shells = "bash,sh"` を追加し、Web UIからPodへのターミナルアクセスを有効化
- RBAC設定（`configs.rbac`）に `exec, create` 権限を `role:app-manager`（ArgoCD Users）に追加

## 関連Issue
- Closes #434

## デプロイ後の確認手順
```bash
# ConfigMap確認
kubectl -n argocd get configmap argocd-cm -o yaml | grep exec

# RBAC確認
kubectl -n argocd get configmap argocd-rbac-cm -o yaml | grep exec

# ClusterRole確認（pods/execが含まれているか）
kubectl get clusterrole -l app.kubernetes.io/part-of=argocd -o yaml | grep -A3 "pods/exec"
```