### PR TITLE
Calendar Bot Webhook の Cloudflare Access バイパスルールを追加

### DIFF
--- a/terraform/access_policies.tf
+++ b/terraform/access_policies.tf
@@ -154,12 +154,40 @@ resource "cloudflare_zero_trust_access_application" "calendar_bot" {
   }]
 }
 
+# Google Calendar Bot Webhook - 認証バイパス（Google Push通知受信用）
+resource "cloudflare_zero_trust_access_application" "calendar_bot_webhook" {
+  account_id                = var.cloudflare_account_id
+  name                      = "Google Calendar Bot Webhook"
+  domain                    = "${local.desktop_services.calendar_bot}/api/webhook/calendar"
+  type                      = "self_hosted"
+  session_duration          = "24h"
+  auto_redirect_to_identity = false
+  enable_binding_cookie     = false
+  options_preflight_bypass  = false
+
+  policies = [{
+    id         = cloudflare_zero_trust_access_policy.webhook_bypass.id
+    precedence = 1
+  }]
+}
+
 
 # ========================================
 # CloudFlare Zero Trust Access Policies
 # ========================================
 # 全ApplicationでOIDC認証Policyを共有
 # ========================================
+
+# 共有Policy: Webhookバイパス（認証不要な外部連携パス用）
+resource "cloudflare_zero_trust_access_policy" "webhook_bypass" {
+  account_id = var.cloudflare_account_id
+  name       = "Webhook Bypass"
+  decision   = "bypass"
+
+  include = [{
+    everyone = {}
+  }]
+}
 
 # 共有Policy: OIDC groups claim認証
 resource "cloudflare_zero_trust_access_policy" "oidc_groups_allow" {

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -12,6 +12,7 @@ output "access_application_ids" {
     opensearch_dashboards = cloudflare_zero_trust_access_application.opensearch_dashboards.id
     argocd                = cloudflare_zero_trust_access_application.argocd.id
     calendar_bot          = cloudflare_zero_trust_access_application.calendar_bot.id
+    calendar_bot_webhook  = cloudflare_zero_trust_access_application.calendar_bot_webhook.id
   }
 }
 
@@ -46,11 +47,11 @@ output "tunnel_endpoints" {
 output "authentik_applications" {
   description = "Authentik Application slugs"
   value = {
-    couchdb              = authentik_application.couchdb.slug
+    couchdb               = authentik_application.couchdb.slug
     cloudflare_zero_trust = authentik_application.cloudflare_zero_trust.slug
-    grafana              = authentik_application.grafana.slug
+    grafana               = authentik_application.grafana.slug
     opensearch_dashboards = authentik_application.opensearch_dashboards.slug
-    wg_lease             = authentik_application.wg_lease.slug
-    argocd               = authentik_application.argocd.slug
+    wg_lease              = authentik_application.wg_lease.slug
+    argocd                = authentik_application.argocd.slug
   }
 }


### PR DESCRIPTION
## 概要
- Google Calendar Bot の Webhook パス (`/api/webhook/calendar`) に対する Cloudflare Access バイパスルールを追加
- 汎用的な `webhook_bypass` ポリシーを新規作成し、今後他サービスの Webhook にも再利用可能な設計
- Webhook 専用の Access Application を追加し、パス単位でバイパスを適用

## 関連Issue
- なし