### PR TITLE
Claude Codeステータスラインスクリプトを追加

### DIFF
--- a/home/modules/development/ai-tools.nix
+++ b/home/modules/development/ai-tools.nix
@@ -24,4 +24,9 @@
       ユーザーには日本語で応答してください。
     '';
   };
+
+  home.file.".claude/statusline.sh" = {
+    source = ./claude-statusline.sh;
+    executable = true;
+  };
 }

--- a/home/modules/development/claude-statusline.sh
+++ b/home/modules/development/claude-statusline.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+input=$(cat)
+MODEL=$(echo "$input" | jq -r '.model.display_name')
+PCT=$(echo "$input" | jq -r '.context_window.used_percentage // 0' | cut -d. -f1)
+echo "[$MODEL] Context: ${PCT}%"


### PR DESCRIPTION
## 概要
- Claude Codeのコンテキストウィンドウ利用率をステータスラインに常時表示するスクリプトを追加
- `~/.claude/statusline.sh` としてHome Managerで配置（実行権限付き）
- モデル名とコンテキスト利用率(%)を `[Model] Context: XX%` 形式で表示

## 関連Issue
- Closes #451