### PR TITLE
statuslineスクリプトのshebangをenv bashに修正

### DIFF
--- a/home/modules/development/claude-statusline.sh
+++ b/home/modules/development/claude-statusline.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 input=$(cat)
 MODEL=$(echo "$input" | jq -r '.model.display_name')
 PCT=$(echo "$input" | jq -r '.context_window.used_percentage // 0' | cut -d. -f1)


### PR DESCRIPTION
## 概要
- NixOSでは`/bin/bash`が存在しないため、`#!/usr/bin/env bash`に修正

## 関連Issue
- #451