### PR TITLE
nixos-observabilityのflake inputを更新

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -313,11 +313,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772671169,
-        "narHash": "sha256-HFFj5DqET2/3gK7YLGEbjjZQXrHERgE9HZdbk/+WhBo=",
+        "lastModified": 1772880817,
+        "narHash": "sha256-PySDG5A5jiIFMAXsI/mPxKCqtL6HiHVZZK832/ZuUz4=",
         "owner": "shinbunbun",
         "repo": "nixos-observability",
-        "rev": "2b7deff2d50d260d411d6e48a63817150b3b4a71",
+        "rev": "a2bcac64775212edbdc9517cb398f1daac11020d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## 概要
- nixos-observabilityのflake inputを更新（データソースUID指定追加を反映）
- Grafanaダッシュボード（k8s-overviewなど）のデータソース参照が正しく解決されるようになる