### PR TITLE
macminiのGitHub Actionsデプロイ対応

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,7 +76,7 @@ jobs:
 
   notify-build-complete:
     name: Notify build completion
-    needs: build-nixos
+    needs: [build-nixos, build-darwin]
     runs-on: ubuntu-latest
     if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/fix/deploy') && github.event_name == 'push' && !inputs.skip_deploy
     steps:
@@ -99,6 +99,28 @@ jobs:
       ssh-hostname: homemachine
       ssh-host: "192.168.1.3"
       needs-sops: true
+    secrets:
+      AUTHENTIK_CLIENT_ID: ${{ secrets.AUTHENTIK_CLIENT_ID }}
+      ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
+      ATTIC_READ_TOKEN: ${{ secrets.ATTIC_READ_TOKEN }}
+      DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+      SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY }}
+
+  deploy-macmini:
+    name: Deploy to macmini
+    needs: [build-darwin, notify-build-complete]
+    if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/fix/deploy') && github.event_name == 'push' && !inputs.skip_deploy
+    uses: shinbunbun/nix-ci-workflows/.github/workflows/deploy-nix.yaml@main
+    with:
+      environment: production
+      deploy-target: ".#macmini"
+      ssh-hostname: macmini
+      ssh-host: "192.168.1.5"
+      ssh-port: '22'
+      ssh-user: 'deploy'
+      needs-sops: true
+      needs-wireguard: true
     secrets:
       AUTHENTIK_CLIENT_ID: ${{ secrets.AUTHENTIK_CLIENT_ID }}
       ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}

--- a/flake.nix
+++ b/flake.nix
@@ -234,9 +234,23 @@
             user = "root";
           };
         };
+
+        macmini = {
+          hostname = "macmini"; # SSH config の Host名（WireGuard VPN経由）
+          fastConnection = false; # WireGuard VPN経由なのでfalse
+          interactiveSudo = false;
+          remoteBuild = true; # リモートマシンでビルド（deployユーザーはtrusted-user）
+
+          profiles.system = {
+            sshUser = "deploy"; # デプロイ専用ユーザー
+            path = deploy-rs.lib.aarch64-darwin.activate.darwin self.darwinConfigurations.macmini;
+            user = "root";
+          };
+        };
       };
 
-      # deploy-rs checks（デプロイ先がx86_64-linuxのみのため、該当システムに限定）
+      # deploy-rs checks
       checks."x86_64-linux" = deploy-rs.lib.x86_64-linux.deployChecks self.deploy;
+      checks."aarch64-darwin" = deploy-rs.lib.aarch64-darwin.deployChecks self.deploy;
     };
 }

--- a/systems/darwin/configurations/macmini/default.nix
+++ b/systems/darwin/configurations/macmini/default.nix
@@ -23,7 +23,9 @@ in
     # 基本モジュール
     ../../modules/base.nix
     ../../modules/optimise.nix
-    # WireGuardは不要
+
+    # デプロイ用ユーザー
+    ../../modules/deploy-user.nix
 
     # 監視・ログ収集
     ../../modules/node-exporter.nix

--- a/systems/darwin/modules/deploy-user.nix
+++ b/systems/darwin/modules/deploy-user.nix
@@ -1,0 +1,50 @@
+/*
+  Darwin用デプロイ専用ユーザー設定モジュール
+
+  CI/CDからの自動デプロイ用ユーザー設定を提供します：
+  - deploy ユーザーの SSH 公開鍵認証（activation script 経由）
+  - Nix trusted-user 権限
+  - NOPASSWD sudo 権限（deploy-rs の activation に必要）
+
+  前提条件:
+  - deploy ユーザーは macOS 上で手動作成が必要（dscl コマンド）
+  - SSH 公開鍵は SOPS で管理
+*/
+{
+  config,
+  lib,
+  inputs,
+  ...
+}:
+let
+  cfg = import ../../../shared/config.nix;
+  deployUser = cfg.deploy.user;
+in
+{
+  # SOPS シークレット
+  sops.secrets."deploy_ssh_public_key" = {
+    sopsFile = "${inputs.self}/secrets/deploy.yaml";
+    mode = "0444";
+  };
+
+  # SSH authorized_keys を activation script で配置
+  # nix-darwin の keyFiles はビルド時にファイルを読むため、SOPS ランタイムパスが使えない
+  system.activationScripts.postActivation.text = lib.mkAfter ''
+    # deploy ユーザーの SSH authorized_keys を SOPS シークレットから配置
+    if [ -d /Users/${deployUser} ]; then
+      mkdir -p /Users/${deployUser}/.ssh
+      cp ${config.sops.secrets."deploy_ssh_public_key".path} /Users/${deployUser}/.ssh/authorized_keys
+      chown -R ${deployUser}:staff /Users/${deployUser}/.ssh
+      chmod 700 /Users/${deployUser}/.ssh
+      chmod 600 /Users/${deployUser}/.ssh/authorized_keys
+    fi
+  '';
+
+  # Nix trusted-user 設定
+  nix.settings.trusted-users = [ deployUser ];
+
+  # NOPASSWD sudo（sudoers.d に配置）
+  environment.etc."sudoers.d/deploy" = {
+    text = "${deployUser} ALL=(ALL) NOPASSWD: ALL";
+  };
+}


### PR DESCRIPTION
## 概要
- Darwin用 `deploy-user.nix` モジュールを新規作成（SSH公開鍵認証・NOPASSWD sudo・trusted-user設定）
- `macmini/default.nix` に deploy-user モジュールを追加
- `flake.nix` に macmini の deploy-rs ノードを追加（`aarch64-darwin.activate.darwin`）
- `ci.yaml` に `deploy-macmini` ジョブを追加（WireGuard VPN経由、SSHポート22）
- `notify-build-complete` を `build-nixos` と `build-darwin` 両方に依存するよう変更

## 前提条件（手動作業）
macmini 上で deploy ユーザーを事前作成する必要があります：
```bash
sudo dscl . -create /Users/deploy
sudo dscl . -create /Users/deploy UserShell /bin/bash
sudo dscl . -create /Users/deploy NFSHomeDirectory /Users/deploy
sudo dscl . -create /Users/deploy UniqueID 550
sudo dscl . -create /Users/deploy PrimaryGroupID 20
sudo mkdir -p /Users/deploy
sudo chown deploy:staff /Users/deploy
```

## 注意事項
- nix-ci-workflows の WireGuard AllowedIPs 変更（PR #16）が先にマージされている必要があります
- `secrets/deploy.yaml` の SOPS 設定は macmini の Age 鍵で既に復号可能（`.sops.yaml` 確認済み）
- deploy-rs の Darwin activate は NixOS ほどの実績がないため、マージ前にローカルテスト推奨

## 関連Issue
- Closes #376