### PR TITLE
deployユーザーのログインシェルを/bin/zshに変更

### DIFF
--- a/systems/darwin/modules/deploy-user.nix
+++ b/systems/darwin/modules/deploy-user.nix
@@ -37,6 +37,15 @@ in
       chown -R ${deployUser}:staff /Users/${deployUser}/.ssh
       chmod 700 /Users/${deployUser}/.ssh
       chmod 600 /Users/${deployUser}/.ssh/authorized_keys
+
+      # deploy ユーザーのログインシェルを /bin/zsh に設定
+      # ssh-ng:// プロトコルでの nix-daemon 実行時に /etc/zshenv が読まれ、
+      # Nix の PATH（/run/current-system/sw/bin 等）が設定されるために必要
+      currentShell=$(dscl . -read /Users/${deployUser} UserShell 2>/dev/null | awk '{print $2}')
+      if [ "$currentShell" != "/bin/zsh" ]; then
+        echo "Setting deploy user shell to /bin/zsh (was: $currentShell)"
+        dscl . -create /Users/${deployUser} UserShell /bin/zsh
+      fi
     fi
   '';
 


### PR DESCRIPTION
## 概要
- macmini への deploy-rs デプロイが `nix-daemon: command not found` で失敗する問題を修正
- deploy ユーザーのログインシェルを `/bin/bash` から `/bin/zsh` に変更する activation script を追加
- zsh は `/etc/zshenv` を全モード（非インタラクティブ含む）で読むため、nix-darwin の PATH 設定（`/run/current-system/sw/bin` 等）が SSH コマンド実行時にも適用される

## 関連Issue
- CI の macmini デプロイジョブ初回実行失敗（`ssh-ng://deploy@macmini` 経由で `nix-daemon` が見つからない）