### PR TITLE
macminiにSSH公開鍵を追加

### DIFF
--- a/systems/darwin/configurations/macmini/default.nix
+++ b/systems/darwin/configurations/macmini/default.nix
@@ -66,6 +66,7 @@ in
   # SSH公開鍵認証（nix-darwinのAuthorizedKeysCommand経由で配置）
   users.users.${username}.openssh.authorizedKeys.keys = [
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPsh7m83p/bIrnzDVYUTzNfw9OAgVH1nu80Qg2TElgVL"
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJK+wjiXKIKrct/Gyo8xWOEbW6HhSctTZyspRUCAdO2H"
   ];
 
   # SOPS設定（Atticプライベートキャッシュ用netrc）


### PR DESCRIPTION
## 概要
- macminiの`authorizedKeys.keys`に新しいSSH公開鍵（ssh-ed25519）を追加
- この鍵でmacminiへのSSH接続を可能にする