### PR TITLE
MLX-LMサーバーをLAN内からアクセス可能にする

### DIFF
--- a/home/modules/development/llm-tools.nix
+++ b/home/modules/development/llm-tools.nix
@@ -41,6 +41,8 @@ in
         "server"
         "--model"
         cfg.mlxLm.model
+        "--host"
+        "0.0.0.0" # LAN内の他マシンからもアクセス可能にする
         "--port"
         (builtins.toString cfg.mlxLm.port)
         "--prompt-cache-bytes"


### PR DESCRIPTION
## 概要
- `--host 0.0.0.0` を追加し、LAN内の他マシンからもMLX-LM APIサーバーにアクセスできるようにした
- 変更前は `127.0.0.1` にバインドされており、ローカルからのみアクセス可能だった