### PR TITLE
Samba macOS接続安定性設定を追加

### DIFF
--- a/shared/sections/infrastructure.nix
+++ b/shared/sections/infrastructure.nix
@@ -53,6 +53,9 @@ v: {
     enable = v.assertBool "samba.enable" false;
     workgroup = v.assertString "samba.workgroup" "WORKGROUP";
     serverString = v.assertString "samba.serverString" "NixOS NAS";
+    keepalive = v.assertNonNegativeInt "samba.keepalive" 60;
+    deadTime = v.assertNonNegativeInt "samba.deadTime" 0;
+    serverMultiChannelSupport = v.assertBool "samba.serverMultiChannelSupport" false;
   };
 
   attic = {

--- a/systems/nixos/modules/services/samba.nix
+++ b/systems/nixos/modules/services/samba.nix
@@ -3,6 +3,7 @@
 
   機能:
   - SMB3以上のプロトコルのみ対応（セキュリティ確保）
+  - macOS接続安定性（keepalive、マルチチャネル制御）
   - macOS互換VFS（fruit, streams_xattr）
   - ゲストアクセス禁止
   - journaldログ出力（既存FluentBit経由でLoki/Grafanaに自動収集）
@@ -17,6 +18,9 @@ let
   enable = cfg.samba.enable;
   workgroup = cfg.samba.workgroup;
   serverString = cfg.samba.serverString;
+  keepalive = cfg.samba.keepalive;
+  deadTime = cfg.samba.deadTime;
+  serverMultiChannelSupport = cfg.samba.serverMultiChannelSupport;
   allowedNetworks = cfg.networking.allowedNetworks;
 
   # allowedNetworksをSamba hosts allow形式に変換
@@ -53,6 +57,11 @@ in
           # アクセス制御
           "hosts allow" = hostsAllow;
           "hosts deny" = "0.0.0.0/0";
+
+          # macOS接続安定性
+          "keepalive" = keepalive;
+          "dead time" = deadTime;
+          "server multi channel support" = if serverMultiChannelSupport then "yes" else "no";
 
           # パフォーマンス
           "use sendfile" = "yes";


### PR DESCRIPTION
## 概要
- macOSからのSMB接続で発生する再接続ループ（`smb_iod_start_reconnect` / `STATUS_IO_TIMEOUT`）を解消するため、Samba globalセクションにkeepalive関連設定を追加
- `keepalive = 60`（60秒間隔のkeepaliveパケット送信）
- `dead time = 0`（アイドル切断を無効化）
- `server multi channel support = no`（macOSのマルチチャネル接続失敗を回避）

## 変更ファイル
- `shared/sections/infrastructure.nix` — samba設定値の定義追加
- `systems/nixos/modules/services/samba.nix` — Samba globalセクションに設定反映

## 検証
- `nix flake check` — 評価エラーなし
- `nix fmt` — フォーマット準拠（0 changed）
- デプロイ後、LokiクエリでmacminiのSMBエラーレート低下を確認予定