### PR TITLE
macOS SMBマルチチャネルを無効化

### DIFF
--- a/systems/darwin/configurations/macmini/default.nix
+++ b/systems/darwin/configurations/macmini/default.nix
@@ -27,6 +27,9 @@ in
     # デプロイ用ユーザー
     ../../modules/deploy-user.nix
 
+    # SMBクライアント設定
+    ../../modules/smb-client.nix
+
     # 監視・ログ収集
     ../../modules/node-exporter.nix
     ../../modules/fluent-bit.nix

--- a/systems/darwin/modules/smb-client.nix
+++ b/systems/darwin/modules/smb-client.nix
@@ -1,0 +1,20 @@
+/*
+  macOS SMBクライアント設定
+
+  機能:
+  - SMBマルチチャネルの無効化（mc_on=no）
+
+  背景:
+  - macOSのSMBマルチチャネル実装は不完全で、シングルNICサーバーに対して
+    smb2_mc_update_main_channel / smb_iod_start_reconnect エラーを引き起こす
+  - サーバー側で無効化しても、macOSクライアントは定期的にインターフェーススキャンを試行する
+*/
+{ ... }:
+{
+  environment.etc."nsmb.conf" = {
+    text = ''
+      [default]
+      mc_on=no
+    '';
+  };
+}


### PR DESCRIPTION
## 概要
- macOS SMBクライアントのマルチチャネル機能を無効化（`/etc/nsmb.conf` に `mc_on=no`）
- シングルNICのSambaサーバーに対する `smb2_mc_update_main_channel` / `smb_iod_start_reconnect` エラーを解消
- macminiのみに適用（macbook/mx-macbookはSamba共有未使用のため対象外）