### PR TITLE
macminiのSMB関連エラーを修正

### DIFF
--- a/systems/darwin/modules/node-exporter.nix
+++ b/systems/darwin/modules/node-exporter.nix
@@ -35,7 +35,7 @@ in
           + "--collector.uname "
           + "--web.listen-address=:${toString nodeExporterPort} "
           + ''--collector.filesystem.mount-points-exclude='^/(dev|nix|System/Volumes/(VM|Preboot|Update|xarts|iSCPreboot|Hardware)|private/var/run/secrets\.d)($|/)' ''
-          + "--collector.filesystem.fs-types-exclude='^(autofs|devfs)$' "
+          + "--collector.filesystem.fs-types-exclude='^(autofs|devfs|smbfs)$' "
           + "--no-collector.thermal "
           + "--collector.netdev.device-exclude='^(utun|awdl|llw|bridge|gif|stf|ap).*$' "
         )

--- a/systems/nixos/modules/services/samba.nix
+++ b/systems/nixos/modules/services/samba.nix
@@ -51,6 +51,9 @@ in
           "fruit:wipe_intentionally_left_blank_rfork" = "yes";
           "fruit:delete_empty_adfiles" = "yes";
 
+          # Time Machine無効化（TM非対応の共有でカーネルエラーを防止）
+          "fruit:time machine" = "no";
+
           # ログ設定
           logging = "systemd";
 


### PR DESCRIPTION
## 概要
- node_exporterのfilesystemコレクターでsmbfsを除外し、CacheDeleteCopyAvailableSpaceForVolumeエラーを解消
- SambaグローバルにTime Machine無効化設定（fruit:time machine = "no"）を追加し、カーネルのTMエンタイトルメントチェックエラーを解消