### PR TITLE
nixos-observability-configの参照を更新（SMB再接続ノイズフィルタ）

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -333,11 +333,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774227220,
-        "narHash": "sha256-rXYTnIeg1KTJH1FxIMUurUhs5Ne7dveOX6uLNoC2yus=",
+        "lastModified": 1774241484,
+        "narHash": "sha256-rrLwuYTJnG8iqEus7g4Ahj5q8fsTl/CFNK7Qz3pneAw=",
         "owner": "shinbunbun",
         "repo": "nixos-observability-config",
-        "rev": "acb7e39ce24752290e2eaa21dd66758c1a1768e5",
+        "rev": "a31a05a9a9f4c6cede3f01579339776d26b7986c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## 概要
- nixos-observability-configの参照を更新（SMB再接続ノイズエラーのフィルタ追加を取り込み）