### PR TITLE
Jellyfinメディアサーバーモジュールを追加

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -215,6 +215,7 @@
           argocd = ./systems/nixos/modules/services/argocd.nix;
           mosh = ./systems/nixos/modules/services/mosh.nix;
           samba = ./systems/nixos/modules/services/samba.nix;
+          jellyfin = ./systems/nixos/modules/services/jellyfin.nix;
         };
       };
 

--- a/shared/config.nix
+++ b/shared/config.nix
@@ -126,6 +126,10 @@ let
       name = "peerIssuer.router";
       port = config.peerIssuer.routerPort;
     }
+    {
+      name = "jellyfin";
+      port = config.jellyfin.port;
+    }
   ];
 
   # ポート衝突の自動検出

--- a/shared/sections/services.nix
+++ b/shared/sections/services.nix
@@ -40,6 +40,11 @@ v: {
     port = v.assertPort "mlxLm.port" 8081;
   };
 
+  jellyfin = {
+    enable = v.assertBool "jellyfin.enable" false;
+    port = v.assertPort "jellyfin.port" 8096;
+  };
+
   routerosBackup = {
     routerIP = v.assertIP "routerosBackup.routerIP" "192.168.1.1";
     routerUser = v.assertString "routerosBackup.routerUser" "admin";

--- a/systems/nixos/modules/services/jellyfin.nix
+++ b/systems/nixos/modules/services/jellyfin.nix
@@ -1,0 +1,30 @@
+/*
+  Jellyfin - メディアサーバー
+
+  機能:
+  - メディアファイルのストリーミング再生
+  - VAAPI によるハードウェアトランスコード
+
+  設定:
+  - デフォルトポート8096でリッスン
+  - jellyfinユーザーにrender/videoグループ付与（GPU利用）
+*/
+{ lib, ... }:
+let
+  cfg = import ../../../../shared/config.nix;
+  enable = cfg.jellyfin.enable;
+in
+{
+  config = lib.mkIf enable {
+    services.jellyfin = {
+      enable = true;
+      openFirewall = true;
+    };
+
+    # ハードウェアトランスコード用グループ
+    users.users.jellyfin.extraGroups = [
+      "render"
+      "video"
+    ];
+  };
+}


### PR DESCRIPTION
## 概要
- Jellyfinメディアサーバーの汎用NixOSモジュールを追加
- `shared/sections/services.nix`: jellyfin設定値（enable, port）
- `shared/config.nix`: ポートレジストリにjellyfin追加
- `systems/nixos/modules/services/jellyfin.nix`: サービスモジュール（openFirewall, render/videoグループ）
- `flake.nix`: nixosModules.services.jellyfinエクスポート