### PR TITLE
Nextcloudファイル管理モジュールを追加

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -216,6 +216,7 @@
           mosh = ./systems/nixos/modules/services/mosh.nix;
           samba = ./systems/nixos/modules/services/samba.nix;
           jellyfin = ./systems/nixos/modules/services/jellyfin.nix;
+          nextcloud = ./systems/nixos/modules/services/nextcloud.nix;
         };
       };
 

--- a/shared/config.nix
+++ b/shared/config.nix
@@ -130,6 +130,10 @@ let
       name = "jellyfin";
       port = config.jellyfin.port;
     }
+    {
+      name = "nextcloud";
+      port = config.nextcloud.port;
+    }
   ];
 
   # ポート衝突の自動検出

--- a/shared/sections/services.nix
+++ b/shared/sections/services.nix
@@ -45,6 +45,12 @@ v: {
     port = v.assertPort "jellyfin.port" 8096;
   };
 
+  nextcloud = {
+    enable = v.assertBool "nextcloud.enable" false;
+    port = v.assertPort "nextcloud.port" 8443;
+    domain = v.assertString "nextcloud.domain" "nextcloud.local";
+  };
+
   routerosBackup = {
     routerIP = v.assertIP "routerosBackup.routerIP" "192.168.1.1";
     routerUser = v.assertString "routerosBackup.routerUser" "admin";

--- a/systems/nixos/modules/services/nextcloud.nix
+++ b/systems/nixos/modules/services/nextcloud.nix
@@ -1,0 +1,54 @@
+/*
+  Nextcloud - ファイル管理・共有プラットフォーム
+
+  機能:
+  - ファイルの同期・共有（WebDAV対応）
+  - nginxによるWebサーバー自動設定
+  - カスタムポートでのリッスン（デフォルト80を回避）
+
+  設定:
+  - shared/config.nix の nextcloud セクションで有効化
+  - hostName は nextcloud.domain から取得
+  - nginx のリッスンポートは nextcloud.port でカスタマイズ
+  - adminpassFile 等のシークレットはホスト固有設定で注入
+*/
+{ lib, pkgs, ... }:
+let
+  cfg = import ../../../../shared/config.nix;
+  enable = cfg.nextcloud.enable;
+  port = cfg.nextcloud.port;
+  domain = cfg.nextcloud.domain;
+in
+{
+  config = lib.mkIf enable {
+    services.nextcloud = {
+      enable = true;
+      package = pkgs.nextcloud32;
+      hostName = domain;
+
+      # SQLite（小規模利用、将来PostgreSQLに移行可能）
+      config.dbtype = "sqlite";
+
+      # ログはjournald出力（既存FluentBit経由でLoki/Grafanaに自動収集）
+      settings.log_type = "systemd";
+
+      # 日本語環境
+      settings.default_phone_region = "JP";
+
+      # 最大アップロードサイズ
+      maxUploadSize = "10G";
+    };
+
+    # nginxのリッスンポートをカスタマイズ
+    # NixOSのnextcloudモジュールが自動生成するvirtualHostのデフォルトポート(80)を上書き
+    services.nginx.virtualHosts.${domain}.listen = [
+      {
+        addr = "0.0.0.0";
+        port = port;
+      }
+    ];
+
+    # ファイアウォール: カスタムポートを許可
+    networking.firewall.allowedTCPPorts = [ port ];
+  };
+}


### PR DESCRIPTION
## 概要
- NAS Phase 3として、Nextcloud（ファイル管理・共有プラットフォーム）のNixOSモジュールを追加
- `shared/sections/services.nix`: nextcloud設定値（enable, port, domain）を追加
- `shared/config.nix`: ポートレジストリにnextcloud（8443）を登録
- `systems/nixos/modules/services/nextcloud.nix`: サービスモジュール新規作成
  - nextcloud32パッケージ使用
  - nginxカスタムポート（8443）でのリッスン
  - SQLite（小規模利用）、journaldログ出力
  - adminpassFile等のシークレットはホスト固有設定で注入する設計
- `flake.nix`: `nixosModules.services.nextcloud`をエクスポート