### PR TITLE
Nextcloud OIDC SSO・Cloudflare Tunnel公開を追加

### DIFF
--- a/shared/sections/management.nix
+++ b/shared/sections/management.nix
@@ -49,6 +49,9 @@ v: {
       argocd = {
         domain = v.assertString "cloudflare.desktop.argocd.domain" "argocd.shinbunbun.com";
       };
+      nextcloud = {
+        domain = v.assertString "cloudflare.desktop.nextcloud.domain" "nextcloud.shinbunbun.com";
+      };
     };
   };
 }

--- a/shared/sections/services.nix
+++ b/shared/sections/services.nix
@@ -48,7 +48,7 @@ v: {
   nextcloud = {
     enable = v.assertBool "nextcloud.enable" false;
     port = v.assertPort "nextcloud.port" 8443;
-    domain = v.assertString "nextcloud.domain" "nextcloud.local";
+    domain = v.assertString "nextcloud.domain" "nextcloud.shinbunbun.com";
   };
 
   routerosBackup = {

--- a/systems/nixos/modules/services/desktop-cloudflare-tunnel.nix
+++ b/systems/nixos/modules/services/desktop-cloudflare-tunnel.nix
@@ -92,6 +92,16 @@ in
               originServerName = "${tunnelConfig.argocd.domain}";
             };
           };
+
+          # Nextcloud - Zero Trust Accessで認証必要
+          "${tunnelConfig.nextcloud.domain}" = {
+            service = "http://localhost:${toString cfg.nextcloud.port}";
+            originRequest = {
+              noTLSVerify = true;
+              httpHostHeader = "${tunnelConfig.nextcloud.domain}";
+              originServerName = "${tunnelConfig.nextcloud.domain}";
+            };
+          };
         };
       };
     };

--- a/terraform/access_policies.tf
+++ b/terraform/access_policies.tf
@@ -136,6 +136,24 @@ resource "cloudflare_zero_trust_access_application" "opensearch_dashboards" {
   }]
 }
 
+# Nextcloud - 認証必須
+resource "cloudflare_zero_trust_access_application" "nextcloud" {
+  account_id                = var.cloudflare_account_id
+  name                      = "Nextcloud"
+  domain                    = local.desktop_services.nextcloud
+  type                      = "self_hosted"
+  session_duration          = "24h"
+  auto_redirect_to_identity = true
+  allowed_idps              = [var.identity_provider_id]
+  enable_binding_cookie     = false
+  options_preflight_bypass  = false
+
+  policies = [{
+    id         = cloudflare_zero_trust_access_policy.oidc_groups_allow.id
+    precedence = 1
+  }]
+}
+
 # Google Calendar Bot - 認証必須
 resource "cloudflare_zero_trust_access_application" "calendar_bot" {
   account_id                = var.cloudflare_account_id

--- a/terraform/authentik_applications.tf
+++ b/terraform/authentik_applications.tf
@@ -43,6 +43,14 @@ resource "authentik_application" "argocd" {
   policy_engine_mode = "any"
 }
 
+resource "authentik_application" "nextcloud" {
+  name               = "Nextcloud"
+  slug               = "nextcloud"
+  protocol_provider  = authentik_provider_oauth2.nextcloud.id
+  meta_launch_url    = "https://nextcloud.shinbunbun.com"
+  policy_engine_mode = "any"
+}
+
 resource "authentik_application" "wg_lease" {
   name               = "wg-lease"
   slug               = "wg-lease"

--- a/terraform/authentik_providers.tf
+++ b/terraform/authentik_providers.tf
@@ -149,6 +149,35 @@ resource "authentik_provider_oauth2" "argocd" {
   }
 }
 
+# Nextcloud OAuth2
+resource "authentik_provider_oauth2" "nextcloud" {
+  name               = "Nextcloud"
+  authorization_flow = data.authentik_flow.default_authorization_explicit_consent.id
+  invalidation_flow  = data.authentik_flow.default_provider_invalidation.id
+  client_type        = "confidential"
+  client_id          = var.nextcloud_oauth_client_id
+  client_secret      = var.nextcloud_oauth_client_secret
+  signing_key        = data.authentik_certificate_key_pair.es256_jwt_signing.id
+  allowed_redirect_uris = [
+    { matching_mode = "strict", url = "https://nextcloud.shinbunbun.com/apps/user_oidc/code" }
+  ]
+  property_mappings = [
+    authentik_property_mapping_provider_scope.oidc_groups.id,
+    data.authentik_property_mapping_provider_scope.openid.id,
+    data.authentik_property_mapping_provider_scope.email.id,
+    data.authentik_property_mapping_provider_scope.profile.id,
+  ]
+  sub_mode                   = "hashed_user_id"
+  issuer_mode                = "per_provider"
+  include_claims_in_id_token = true
+  access_code_validity       = "minutes=1"
+  access_token_validity      = "minutes=5"
+  refresh_token_validity     = "days=30"
+  lifecycle {
+    ignore_changes = [logout_method, refresh_token_threshold]
+  }
+}
+
 # --- Proxy Provider ---
 
 # wg-lease Proxy Provider（Embedded Outpost経由）

--- a/terraform/dns_records.tf
+++ b/terraform/dns_records.tf
@@ -149,6 +149,17 @@ resource "cloudflare_dns_record" "calendar_bot" {
   comment = "Managed by Terraform - Google Calendar Bot via desktop-services tunnel"
 }
 
+# Nextcloud
+resource "cloudflare_dns_record" "nextcloud" {
+  zone_id = var.cloudflare_zone_id
+  name    = "nextcloud.${local.base_domain}"
+  content = local.desktop_tunnel_endpoint
+  type    = "CNAME"
+  ttl     = 1
+  proxied = true
+  comment = "Managed by Terraform - Nextcloud via desktop-services tunnel"
+}
+
 # mixi2 Bot
 resource "cloudflare_dns_record" "mixi2_bot" {
   zone_id = var.cloudflare_zone_id

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -36,6 +36,7 @@ locals {
     calendar_bot          = "calendar-bot.${local.base_domain}"
     mixi2_bot             = "mixi2-bot.${local.base_domain}"
     argocd                = "argocd.${local.base_domain}"
+    nextcloud             = "nextcloud.${local.base_domain}"
   }
 
   # Cloudflare Tunnel エンドポイント

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -121,6 +121,18 @@ variable "argocd_oauth_client_secret" {
   sensitive   = true
 }
 
+variable "nextcloud_oauth_client_id" {
+  description = "Nextcloud OAuth2 Client ID"
+  type        = string
+  sensitive   = true
+}
+
+variable "nextcloud_oauth_client_secret" {
+  description = "Nextcloud OAuth2 Client Secret"
+  type        = string
+  sensitive   = true
+}
+
 # --- OpenSearch ---
 variable "opensearch_url" {
   description = "OpenSearch URL"


### PR DESCRIPTION
## 概要
- Authentik OAuth2/OIDCプロバイダー・アプリケーションをTerraformで追加（既存のArgoCD/Grafanaパターンに準拠）
- Cloudflare DNS CNAME (`nextcloud.shinbunbun.com`) およびZero Trust Access Applicationを追加
- NixOS Cloudflare TunnelにNextcloudルーティングを追加
- `nextcloud.domain`デフォルト値を`nextcloud.shinbunbun.com`に変更
- `cloudflare.desktop.nextcloud`設定値を追加