### PR TITLE
Nextcloud OAuthシークレット・devshell環境変数を追加

### DIFF
--- a/devshell/default.nix
+++ b/devshell/default.nix
@@ -112,6 +112,9 @@ pkgs.mkShell {
       export TF_VAR_argocd_oauth_client_id=$(sops -d --extract '["argocd"]["oidc_client_id"]' secrets/authentik-terraform.yaml 2>/dev/null)
       export TF_VAR_argocd_oauth_client_secret=$(sops -d --extract '["argocd"]["oidc_client_secret"]' secrets/authentik-terraform.yaml 2>/dev/null)
       [ -n "$TF_VAR_argocd_oauth_client_id" ] && echo "✓ ArgoCD OAuth secrets loaded"
+      export TF_VAR_nextcloud_oauth_client_id=$(sops -d --extract '["nextcloud"]["oauth_client_id"]' secrets/authentik-terraform.yaml 2>/dev/null)
+      export TF_VAR_nextcloud_oauth_client_secret=$(sops -d --extract '["nextcloud"]["oauth_client_secret"]' secrets/authentik-terraform.yaml 2>/dev/null)
+      [ -n "$TF_VAR_nextcloud_oauth_client_id" ] && echo "✓ Nextcloud OAuth secrets loaded"
     fi
     echo ""
 

--- a/secrets/authentik-terraform.yaml
+++ b/secrets/authentik-terraform.yaml
@@ -9,6 +9,9 @@ opensearch:
 argocd:
     oidc_client_id: ENC[AES256_GCM,data:5Mnm9OaO6wj9I1fQcGO9rAbQ4J5hQC/9UKlIWGBrPTcMjMikXtReAA==,iv:RcRspYN6COLNuiP5joWgDWuQijOxM+S1BHFP/tj9aOg=,tag:XjCu9F0embcYOU0F26Eklg==,type:str]
     oidc_client_secret: ENC[AES256_GCM,data:JRk6HbLOfUg0IYez8V0Hg/Jbi0OYoUX9JBpVNAqqxUMPlJ8VQT2n2eXj1b0+PzlJ9K8R0lrtUI/ydQ7OJOCBpQ==,iv:/YcsERT62dgWFjGhE8eDbcbS+ZvjLicYhqqsK3tps7U=,tag:1cAJ9e4UvU4jLC+7vfPbLg==,type:str]
+nextcloud:
+    oauth_client_id: ENC[AES256_GCM,data:0WohsiEX9FSyS1gsLDQNMEePlSq7hNK8aU7MwGaATKc=,iv:Mf6NhaAmxeI0g/POGF4OMt0OmX5OfdPY8ww+/9I66tI=,tag:IpToFOiS1YsXzoqnvrcqiA==,type:str]
+    oauth_client_secret: ENC[AES256_GCM,data:30KM//tVu51o+GpCBp7CoL1ySrsIddohhd4EV6+QqDE7guJXmx6t0uB8XbphUjwD8Cr++ow7rT8xntL6JydccA==,iv:OHyiPdTdUmlnruA9ntcCjhGy/KGNpU8UQdbyrTuLH+8=,tag:V/9ElUhiwaIkxleSAu64aA==,type:str]
 sops:
     age:
         - recipient: age1p057v4es63p6fef8usy67tkza7dj4xg326w5gm3c7rdthcd3xqlqps38z9
@@ -47,7 +50,7 @@ sops:
             WjRtVlJ1Nm82dWdoTFJRZ21oVmk4RG8K89tKy9b9Le0+TewsR/zfkwR3y68wRtmA
             25bYc9VrjBZVfM/GQpCVmNcF+HttkCpxFxukZf8b1spj0UtIsk6Dkg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-02-22T15:10:01Z"
-    mac: ENC[AES256_GCM,data:oLCOXnWVH3Kfz5NTVRGdlBJsw2ATNDwvd3OTkT8pLlhiAWKUMugF9EeIIkdtzZPF3HRRJ1ClNwxD2ZgX0sldZNwsYagHHshZYrD3/fn5bXrtMK0ArI2aZF7eI5v7tMvSWs2R/JCEaRQIlAyT0jvpA9egpxVf+D7ykIV8ZHwfWI0=,iv:ZwqKEdJQmwYE+f9Jl75UIqASEHjLAt9cvCkPeujlBGk=,tag:dq2uHehqZ2zp4liTHm4HAQ==,type:str]
+    lastmodified: "2026-03-25T11:50:59Z"
+    mac: ENC[AES256_GCM,data:t4Dzv2BqXCwf4tIg4jeF27yzQm2YuIQbtLMw2hI/5zA6pvM3z8wMzGjqVd9HIgPIHTG3P+GNNCDiQ3XXreupxKIwJBQZVWtw82oeX5AWUqGlekeMVr5W13K6oYDAjVCsE+CAFCeEJoe1vZX0Kfyvridh//Gi0AxjEGR3vaT7tLE=,iv:1lc+k73nXoh62NxhbEjzG7E4zlhTzDh9XGbozG0AFWo=,tag:c9elm1KkWVKKjEcYklL6cw==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.11.0


### PR DESCRIPTION
## 概要
- `secrets/authentik-terraform.yaml`にnextcloud oauth_client_id/secret追加（SOPS暗号化）
- `devshell/default.nix`にTF_VAR_nextcloud_oauth_*環境変数の読み込み追加