### PR TITLE
Nextcloud Adminsグループ追加とOIDCグループマッピング設定

### DIFF
--- a/terraform/authentik_groups.tf
+++ b/terraform/authentik_groups.tf
@@ -33,3 +33,9 @@ resource "authentik_group" "grafana_admins" {
   is_superuser = false
   users        = [data.authentik_user.shinbunbun.id]
 }
+
+resource "authentik_group" "nextcloud_admins" {
+  name         = "Nextcloud Admins"
+  is_superuser = false
+  users        = [data.authentik_user.shinbunbun.id]
+}

--- a/terraform/authentik_property_mappings.tf
+++ b/terraform/authentik_property_mappings.tf
@@ -12,3 +12,15 @@ resource "authentik_property_mapping_provider_scope" "oidc_groups" {
     return {"groups": [group.name for group in user.ak_groups.all()]}
   EOT
 }
+
+# Nextcloud用: "Nextcloud Admins" → "admin" に変換し、Nextcloud組み込みadminグループと一致させる
+resource "authentik_property_mapping_provider_scope" "nextcloud_groups" {
+  name       = "Nextcloud Groups"
+  scope_name = "groups"
+  expression = <<-EOT
+    group_mapping = {
+        "Nextcloud Admins": "admin",
+    }
+    return {"groups": [group_mapping.get(group.name, group.name) for group in user.ak_groups.all()]}
+  EOT
+}

--- a/terraform/authentik_providers.tf
+++ b/terraform/authentik_providers.tf
@@ -162,7 +162,7 @@ resource "authentik_provider_oauth2" "nextcloud" {
     { matching_mode = "strict", url = "https://nextcloud.shinbunbun.com/apps/user_oidc/code" }
   ]
   property_mappings = [
-    authentik_property_mapping_provider_scope.oidc_groups.id,
+    authentik_property_mapping_provider_scope.nextcloud_groups.id,
     data.authentik_property_mapping_provider_scope.openid.id,
     data.authentik_property_mapping_provider_scope.email.id,
     data.authentik_property_mapping_provider_scope.profile.id,


### PR DESCRIPTION
## 概要
- Authentikに"Nextcloud Admins"グループを作成し、shinbunbunをメンバーに追加
- Nextcloud専用のOIDCグループマッピングを追加（"Nextcloud Admins" → "admin"に変換）
- Nextcloudプロバイダーのproperty_mappingsを専用マッピングに差し替え