### PR TITLE
Immichモジュールを追加（写真・動画管理サーバー）

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -217,6 +217,7 @@
           samba = ./systems/nixos/modules/services/samba.nix;
           jellyfin = ./systems/nixos/modules/services/jellyfin.nix;
           nextcloud = ./systems/nixos/modules/services/nextcloud.nix;
+          immich = ./systems/nixos/modules/services/immich.nix;
         };
       };
 

--- a/shared/config.nix
+++ b/shared/config.nix
@@ -134,6 +134,10 @@ let
       name = "nextcloud";
       port = config.nextcloud.port;
     }
+    {
+      name = "immich";
+      port = config.immich.port;
+    }
   ];
 
   # ポート衝突の自動検出

--- a/shared/sections/services.nix
+++ b/shared/sections/services.nix
@@ -51,6 +51,11 @@ v: {
     domain = v.assertString "nextcloud.domain" "nextcloud.shinbunbun.com";
   };
 
+  immich = {
+    enable = v.assertBool "immich.enable" false;
+    port = v.assertPort "immich.port" 2283;
+  };
+
   routerosBackup = {
     routerIP = v.assertIP "routerosBackup.routerIP" "192.168.1.1";
     routerUser = v.assertString "routerosBackup.routerUser" "admin";

--- a/systems/nixos/modules/services/immich.nix
+++ b/systems/nixos/modules/services/immich.nix
@@ -1,0 +1,27 @@
+/*
+  Immich - 写真・動画管理サーバー
+
+  機能:
+  - 写真・動画の自動バックアップ（iOS/Android対応）
+  - 顔認識・オブジェクト認識（ML）
+  - Intel GPU (OpenVINO) によるML高速化
+
+  設定:
+  - shared/config.nix の immich セクションで有効化
+  - ポートはデフォルト2283
+  - mediaLocation はホスト固有設定で指定
+*/
+{ lib, ... }:
+let
+  cfg = import ../../../../shared/config.nix;
+  enable = cfg.immich.enable;
+in
+{
+  config = lib.mkIf enable {
+    services.immich = {
+      enable = true;
+      port = cfg.immich.port;
+      openFirewall = true;
+    };
+  };
+}


### PR DESCRIPTION
## 概要
- Immich（写真・動画管理サーバー）のNixOSモジュールを追加
- shared/config.nixにimmich設定値・ポートレジストリを追加
- flake.nixにモジュールエクスポートを追加