### PR TITLE
Immich OAuth2/OIDC設定をTerraformに追加（Authentik SSO）

### DIFF
--- a/terraform/authentik_applications.tf
+++ b/terraform/authentik_applications.tf
@@ -51,6 +51,13 @@ resource "authentik_application" "nextcloud" {
   policy_engine_mode = "any"
 }
 
+resource "authentik_application" "immich" {
+  name               = "Immich"
+  slug               = "immich"
+  protocol_provider  = authentik_provider_oauth2.immich.id
+  policy_engine_mode = "any"
+}
+
 resource "authentik_application" "wg_lease" {
   name               = "wg-lease"
   slug               = "wg-lease"

--- a/terraform/authentik_groups.tf
+++ b/terraform/authentik_groups.tf
@@ -39,3 +39,9 @@ resource "authentik_group" "nextcloud_admins" {
   is_superuser = false
   users        = [data.authentik_user.shinbunbun.id]
 }
+
+resource "authentik_group" "immich_admins" {
+  name         = "Immich Admins"
+  is_superuser = false
+  users        = [data.authentik_user.shinbunbun.id]
+}

--- a/terraform/authentik_property_mappings.tf
+++ b/terraform/authentik_property_mappings.tf
@@ -13,6 +13,17 @@ resource "authentik_property_mapping_provider_scope" "oidc_groups" {
   EOT
 }
 
+# Immich用: "Immich Admins" グループ所属ユーザーに admin ロールを付与
+resource "authentik_property_mapping_provider_scope" "immich_role" {
+  name       = "Immich Role"
+  scope_name = "immich"
+  expression = <<-EOT
+    return {
+      "immich_role": "admin" if request.user.ak_groups.filter(name="Immich Admins").exists() else "user"
+    }
+  EOT
+}
+
 # Nextcloud用: "Nextcloud Admins" → "admin" に変換し、Nextcloud組み込みadminグループと一致させる
 resource "authentik_property_mapping_provider_scope" "nextcloud_groups" {
   name       = "Nextcloud Groups"

--- a/terraform/authentik_providers.tf
+++ b/terraform/authentik_providers.tf
@@ -178,6 +178,37 @@ resource "authentik_provider_oauth2" "nextcloud" {
   }
 }
 
+# Immich OAuth2
+resource "authentik_provider_oauth2" "immich" {
+  name               = "Immich"
+  authorization_flow = data.authentik_flow.default_authorization_explicit_consent.id
+  invalidation_flow  = data.authentik_flow.default_provider_invalidation.id
+  client_type        = "confidential"
+  client_id          = var.immich_oauth_client_id
+  client_secret      = var.immich_oauth_client_secret
+  signing_key        = data.authentik_certificate_key_pair.es256_jwt_signing.id
+  allowed_redirect_uris = [
+    { matching_mode = "strict", url = "http://192.168.1.4:2283/auth/login" },
+    { matching_mode = "strict", url = "http://192.168.1.4:2283/user-settings" },
+    { matching_mode = "strict", url = "app.immich:///oauth-callback" },
+  ]
+  property_mappings = [
+    authentik_property_mapping_provider_scope.immich_role.id,
+    data.authentik_property_mapping_provider_scope.openid.id,
+    data.authentik_property_mapping_provider_scope.email.id,
+    data.authentik_property_mapping_provider_scope.profile.id,
+  ]
+  sub_mode                   = "hashed_user_id"
+  issuer_mode                = "per_provider"
+  include_claims_in_id_token = true
+  access_code_validity       = "minutes=1"
+  access_token_validity      = "minutes=5"
+  refresh_token_validity     = "days=30"
+  lifecycle {
+    ignore_changes = [logout_method, refresh_token_threshold]
+  }
+}
+
 # --- Proxy Provider ---
 
 # wg-lease Proxy Provider（Embedded Outpost経由）

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -133,6 +133,18 @@ variable "nextcloud_oauth_client_secret" {
   sensitive   = true
 }
 
+variable "immich_oauth_client_id" {
+  description = "Immich OAuth2 Client ID"
+  type        = string
+  sensitive   = true
+}
+
+variable "immich_oauth_client_secret" {
+  description = "Immich OAuth2 Client Secret"
+  type        = string
+  sensitive   = true
+}
+
 # --- OpenSearch ---
 variable "opensearch_url" {
   description = "OpenSearch URL"


### PR DESCRIPTION
## 概要
- Authentikに Immich OAuth2 Provider/Application を追加
- `Immich Admins` グループを作成し、shinbunbunに管理者ロールを付与
- `immich_role` カスタムScope Mappingでグループベースの管理者判定
- モバイルアプリ用redirect URI (`app.immich:///oauth-callback`) を含む