### PR TITLE
Immich/Jellyfinモジュールのガード条件をconfig.services.*.enableに修正

### DIFF
--- a/systems/nixos/modules/services/immich.nix
+++ b/systems/nixos/modules/services/immich.nix
@@ -11,15 +11,17 @@
   - ポートはデフォルト2283
   - mediaLocation はホスト固有設定で指定
 */
-{ lib, ... }:
+{
+  lib,
+  config,
+  ...
+}:
 let
   cfg = import ../../../../shared/config.nix;
-  enable = cfg.immich.enable;
 in
 {
-  config = lib.mkIf enable {
+  config = lib.mkIf config.services.immich.enable {
     services.immich = {
-      enable = true;
       port = cfg.immich.port;
       openFirewall = true;
     };

--- a/systems/nixos/modules/services/jellyfin.nix
+++ b/systems/nixos/modules/services/jellyfin.nix
@@ -9,15 +9,14 @@
   - デフォルトポート8096でリッスン
   - jellyfinユーザーにrender/videoグループ付与（GPU利用）
 */
-{ lib, ... }:
-let
-  cfg = import ../../../../shared/config.nix;
-  enable = cfg.jellyfin.enable;
-in
 {
-  config = lib.mkIf enable {
+  lib,
+  config,
+  ...
+}:
+{
+  config = lib.mkIf config.services.jellyfin.enable {
     services.jellyfin = {
-      enable = true;
       openFirewall = true;
     };
 


### PR DESCRIPTION
## 概要
- Immich/Jellyfinモジュールの`lib.mkIf`ガード条件を修正
- `cfg.*.enable`（shared/config.nixのデフォルト値`false`）→ `config.services.*.enable`（NixOS実際のサービス状態）に変更
- Nextcloudモジュールと同じパターンに統一
- これにより`openFirewall`やポート設定等がdotfiles-private側での有効化時に正しく適用される