### PR TITLE
Immich OAuth secretsをdirenvで読み込むように追加

### DIFF
--- a/devshell/default.nix
+++ b/devshell/default.nix
@@ -115,6 +115,9 @@ pkgs.mkShell {
       export TF_VAR_nextcloud_oauth_client_id=$(sops -d --extract '["nextcloud"]["oauth_client_id"]' secrets/authentik-terraform.yaml 2>/dev/null)
       export TF_VAR_nextcloud_oauth_client_secret=$(sops -d --extract '["nextcloud"]["oauth_client_secret"]' secrets/authentik-terraform.yaml 2>/dev/null)
       [ -n "$TF_VAR_nextcloud_oauth_client_id" ] && echo "✓ Nextcloud OAuth secrets loaded"
+      export TF_VAR_immich_oauth_client_id=$(sops -d --extract '["immich"]["oauth_client_id"]' secrets/authentik-terraform.yaml 2>/dev/null)
+      export TF_VAR_immich_oauth_client_secret=$(sops -d --extract '["immich"]["oauth_client_secret"]' secrets/authentik-terraform.yaml 2>/dev/null)
+      [ -n "$TF_VAR_immich_oauth_client_id" ] && echo "✓ Immich OAuth secrets loaded"
     fi
     echo ""
 

--- a/secrets/authentik-terraform.yaml
+++ b/secrets/authentik-terraform.yaml
@@ -12,6 +12,9 @@ argocd:
 nextcloud:
     oauth_client_id: ENC[AES256_GCM,data:0WohsiEX9FSyS1gsLDQNMEePlSq7hNK8aU7MwGaATKc=,iv:Mf6NhaAmxeI0g/POGF4OMt0OmX5OfdPY8ww+/9I66tI=,tag:IpToFOiS1YsXzoqnvrcqiA==,type:str]
     oauth_client_secret: ENC[AES256_GCM,data:30KM//tVu51o+GpCBp7CoL1ySrsIddohhd4EV6+QqDE7guJXmx6t0uB8XbphUjwD8Cr++ow7rT8xntL6JydccA==,iv:OHyiPdTdUmlnruA9ntcCjhGy/KGNpU8UQdbyrTuLH+8=,tag:V/9ElUhiwaIkxleSAu64aA==,type:str]
+immich:
+    oauth_client_id: ENC[AES256_GCM,data:H82rc0dkyK1Cxmc6vRg3ITy85CMsyZGYvNNmLjOdnqn3MutbuPhLNEaJ3Pw2gml+rHtYGwvafM+l3NmHVqP59A==,iv:2Gze+JisIY1V1xkkawTZGbwEuG5H7k3ypUyMSF5kYqk=,tag:NkhUmUbzPU8f+GnZctpWQQ==,type:str]
+    oauth_client_secret: ENC[AES256_GCM,data:7YPvGIoDPBIyKkExYpjT708O+MODoqod7HtlUhRQ90I82WTg8V1tDSbXA9hgfofgsMoxFOpgbb6rttULVRKhsylnpsffwTBy5EkNCZyYqMGk5qECdr7C3BPlBY3jhY44IghddxRA9qX6DjqC3Jhr7m0F1iHboaVxYCo/k/T+XRY=,iv:JNGsR+z0j7HPCkQJBK1i1MYvWhTYYWxZRqYB3HydmXc=,tag:0AjOQcKi7VyArtPSrcBFVA==,type:str]
 sops:
     age:
         - recipient: age1p057v4es63p6fef8usy67tkza7dj4xg326w5gm3c7rdthcd3xqlqps38z9
@@ -50,7 +53,7 @@ sops:
             WjRtVlJ1Nm82dWdoTFJRZ21oVmk4RG8K89tKy9b9Le0+TewsR/zfkwR3y68wRtmA
             25bYc9VrjBZVfM/GQpCVmNcF+HttkCpxFxukZf8b1spj0UtIsk6Dkg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-03-25T11:50:59Z"
-    mac: ENC[AES256_GCM,data:t4Dzv2BqXCwf4tIg4jeF27yzQm2YuIQbtLMw2hI/5zA6pvM3z8wMzGjqVd9HIgPIHTG3P+GNNCDiQ3XXreupxKIwJBQZVWtw82oeX5AWUqGlekeMVr5W13K6oYDAjVCsE+CAFCeEJoe1vZX0Kfyvridh//Gi0AxjEGR3vaT7tLE=,iv:1lc+k73nXoh62NxhbEjzG7E4zlhTzDh9XGbozG0AFWo=,tag:c9elm1KkWVKKjEcYklL6cw==,type:str]
+    lastmodified: "2026-03-28T12:02:58Z"
+    mac: ENC[AES256_GCM,data:p7OqrftsD+ayYVcHPCtj8jYmMxGlOT1ipN4gh+l8BBwMyHIEJn5A3ruYEJmCMIPWYPNeuCPd+GBtuymhs9k+uSNHFAnzl+BMDvFM19xo2UgPI0Kf7kE6/OmA0QWcnTofMxTRQi6TvxqVS29elv3nLehB7Ifey2YHAqNZyc7/MzU=,iv:QVay+RLHMMcpYIEpfanrLAuhs78JP32QIvlIeawyA+o=,tag:psP6eHJlFnSAQgjERkLSzA==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.11.0


### PR DESCRIPTION
## 概要
- `secrets/authentik-terraform.yaml` にImmichのOAuth credentials（client_id, client_secret）を追加
- `devshell/default.nix` のshellHookで `TF_VAR_immich_oauth_client_id` / `TF_VAR_immich_oauth_client_secret` を環境変数にエクスポートするように追加
- これにより `terraform plan/apply` 時にImmich OAuth変数の手動入力が不要になる