### PR TITLE
Immich外部公開設定を追加（Cloudflare Tunnel + Zero Trust + Service Token）

### DIFF
--- a/shared/sections/management.nix
+++ b/shared/sections/management.nix
@@ -52,6 +52,9 @@ v: {
       nextcloud = {
         domain = v.assertString "cloudflare.desktop.nextcloud.domain" "nextcloud.shinbunbun.com";
       };
+      immich = {
+        domain = v.assertString "cloudflare.desktop.immich.domain" "immich.shinbunbun.com";
+      };
     };
   };
 }

--- a/shared/sections/services.nix
+++ b/shared/sections/services.nix
@@ -54,6 +54,7 @@ v: {
   immich = {
     enable = v.assertBool "immich.enable" false;
     port = v.assertPort "immich.port" 2283;
+    domain = v.assertString "immich.domain" "immich.shinbunbun.com";
   };
 
   routerosBackup = {

--- a/systems/nixos/modules/services/desktop-cloudflare-tunnel.nix
+++ b/systems/nixos/modules/services/desktop-cloudflare-tunnel.nix
@@ -102,6 +102,16 @@ in
               originServerName = "${tunnelConfig.nextcloud.domain}";
             };
           };
+
+          # Immich - Zero Trust Accessで認証必要（モバイルはService Token）
+          "${tunnelConfig.immich.domain}" = {
+            service = "http://localhost:${toString cfg.immich.port}";
+            originRequest = {
+              noTLSVerify = true;
+              httpHostHeader = "${tunnelConfig.immich.domain}";
+              originServerName = "${tunnelConfig.immich.domain}";
+            };
+          };
         };
       };
     };

--- a/terraform/access_policies.tf
+++ b/terraform/access_policies.tf
@@ -154,6 +154,50 @@ resource "cloudflare_zero_trust_access_application" "nextcloud" {
   }]
 }
 
+# Immich - ブラウザはOIDC認証、モバイルアプリはService Token認証
+resource "cloudflare_zero_trust_access_application" "immich" {
+  account_id                = var.cloudflare_account_id
+  name                      = "Immich"
+  domain                    = local.desktop_services.immich
+  type                      = "self_hosted"
+  session_duration          = "24h"
+  auto_redirect_to_identity = true
+  allowed_idps              = [var.identity_provider_id]
+  enable_binding_cookie     = false
+  options_preflight_bypass  = false
+
+  policies = [
+    {
+      id         = cloudflare_zero_trust_access_policy.oidc_groups_allow.id
+      precedence = 1
+    },
+    {
+      id         = cloudflare_zero_trust_access_policy.immich_service_auth.id
+      precedence = 2
+    },
+  ]
+}
+
+# Service Token（Immichモバイルアプリ用）
+resource "cloudflare_zero_trust_access_service_token" "immich_mobile" {
+  account_id = var.cloudflare_account_id
+  name       = "Immich Mobile App"
+  duration   = "8760h"
+}
+
+# Service Auth Policy（Service Tokenでのアクセスを許可）
+resource "cloudflare_zero_trust_access_policy" "immich_service_auth" {
+  account_id = var.cloudflare_account_id
+  name       = "Immich Service Auth"
+  decision   = "non_identity"
+
+  include = [{
+    service_token = {
+      token_id = cloudflare_zero_trust_access_service_token.immich_mobile.id
+    }
+  }]
+}
+
 # Google Calendar Bot - 認証必須
 resource "cloudflare_zero_trust_access_application" "calendar_bot" {
   account_id                = var.cloudflare_account_id

--- a/terraform/authentik_providers.tf
+++ b/terraform/authentik_providers.tf
@@ -190,6 +190,8 @@ resource "authentik_provider_oauth2" "immich" {
   allowed_redirect_uris = [
     { matching_mode = "strict", url = "http://192.168.1.4:2283/auth/login" },
     { matching_mode = "strict", url = "http://192.168.1.4:2283/user-settings" },
+    { matching_mode = "strict", url = "https://immich.shinbunbun.com/auth/login" },
+    { matching_mode = "strict", url = "https://immich.shinbunbun.com/user-settings" },
     { matching_mode = "strict", url = "app.immich:///oauth-callback" },
   ]
   property_mappings = [

--- a/terraform/dns_records.tf
+++ b/terraform/dns_records.tf
@@ -160,6 +160,17 @@ resource "cloudflare_dns_record" "nextcloud" {
   comment = "Managed by Terraform - Nextcloud via desktop-services tunnel"
 }
 
+# Immich
+resource "cloudflare_dns_record" "immich" {
+  zone_id = var.cloudflare_zone_id
+  name    = "immich.${local.base_domain}"
+  content = local.desktop_tunnel_endpoint
+  type    = "CNAME"
+  ttl     = 1
+  proxied = true
+  comment = "Managed by Terraform - Immich via desktop-services tunnel"
+}
+
 # mixi2 Bot
 resource "cloudflare_dns_record" "mixi2_bot" {
   zone_id = var.cloudflare_zone_id

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -37,6 +37,7 @@ locals {
     mixi2_bot             = "mixi2-bot.${local.base_domain}"
     argocd                = "argocd.${local.base_domain}"
     nextcloud             = "nextcloud.${local.base_domain}"
+    immich                = "immich.${local.base_domain}"
   }
 
   # Cloudflare Tunnel エンドポイント

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -13,7 +13,21 @@ output "access_application_ids" {
     argocd                = cloudflare_zero_trust_access_application.argocd.id
     calendar_bot          = cloudflare_zero_trust_access_application.calendar_bot.id
     calendar_bot_webhook  = cloudflare_zero_trust_access_application.calendar_bot_webhook.id
+    immich                = cloudflare_zero_trust_access_application.immich.id
   }
+}
+
+# Immichモバイルアプリ用Service Token
+output "immich_mobile_service_token_client_id" {
+  description = "Immich Mobile App - CF-Access-Client-Id"
+  value       = cloudflare_zero_trust_access_service_token.immich_mobile.client_id
+  sensitive   = true
+}
+
+output "immich_mobile_service_token_client_secret" {
+  description = "Immich Mobile App - CF-Access-Client-Secret（初回のみ表示）"
+  value       = cloudflare_zero_trust_access_service_token.immich_mobile.client_secret
+  sensitive   = true
 }
 
 # DNSレコード情報


### PR DESCRIPTION
## 概要
- Immichを `immich.shinbunbun.com` でCloudflare Tunnel経由で外部公開
- desktop-servicesトンネルにImmich ingressを追加
- Zero Trust Access Application + OIDC認証ポリシーを追加（ブラウザ用）
- Cloudflare Service Tokenを作成（モバイルアプリ用、CF-Access-Client-Id/Secret ヘッダー認証）
- Authentik OAuth ProviderにHTTPS redirect URIを追加
- DNS CNAMEレコードを追加