### PR TITLE
OpenSearch ISMポリシーのdrift修正

### DIFF
--- a/terraform/opensearch_index_templates.tf
+++ b/terraform/opensearch_index_templates.tf
@@ -68,7 +68,8 @@ resource "opensearch_ism_policy" "logs_lifecycle" {
       }]
       states = [
         {
-          name = "hot"
+          name    = "hot"
+          actions = []
           transitions = [{
             state_name = "warm"
             conditions = {
@@ -83,9 +84,19 @@ resource "opensearch_ism_policy" "logs_lifecycle" {
               force_merge = {
                 max_num_segments = 1
               }
+              retry = {
+                backoff = "exponential"
+                count   = 3
+                delay   = "1m"
+              }
             },
             {
               read_only = {}
+              retry = {
+                backoff = "exponential"
+                count   = 3
+                delay   = "1m"
+              }
             }
           ]
           transitions = [{
@@ -96,8 +107,15 @@ resource "opensearch_ism_policy" "logs_lifecycle" {
           }]
         },
         {
-          name        = "close"
-          actions     = [{ close = {} }]
+          name = "close"
+          actions = [{
+            close = {}
+            retry = {
+              backoff = "exponential"
+              count   = 3
+              delay   = "1m"
+            }
+          }]
           transitions = []
         }
       ]


### PR DESCRIPTION
## 概要
- OpenSearchがISMポリシー作成時に自動付与するデフォルト値（`retry`ブロック、空`actions`）をTerraformコードに明示
- `terraform plan`で差分が出なくなる