### PR TITLE
macbookのbrew caskにbalenaetcherを追加

### DIFF
--- a/systems/darwin/configurations/macbook/default.nix
+++ b/systems/darwin/configurations/macbook/default.nix
@@ -77,6 +77,7 @@ in
       "vnc-viewer" # VNCクライアント
       "1password"
       "vlc"
+      "balenaetcher" # USBブートメディア作成ツール
     ];
     masApps = {
       # Apple製アプリ


### PR DESCRIPTION
## 概要
- macbookのbrew cask設定にbalenaetcher（USBブートメディア作成ツール）を追加