### PR TITLE
homeMachine: Prometheusのscrapeターゲットにg3proを追加

### DIFF
--- a/systems/nixos/configurations/homeMachine/observability.nix
+++ b/systems/nixos/configurations/homeMachine/observability.nix
@@ -182,6 +182,14 @@ in
                   instance = cfg.networking.hosts.macmini.hostname;
                 };
               }
+              {
+                targets = [
+                  "${cfg.networking.hosts.g3pro.ip}:${toString cfg.monitoring.nodeExporter.port}"
+                ];
+                labels = {
+                  instance = cfg.networking.hosts.g3pro.hostname;
+                };
+              }
             ];
           }
           {


### PR DESCRIPTION
## 概要
- homeMachineのPrometheus scrape設定にg3pro (192.168.1.6:9100) をnodeジョブのターゲットとして追加
- g3proのNode Exporterメトリクスが収集され、アラート（InstanceDown, HighCPUUsage等）が有効になる