### PR TITLE
k3s 3ノードHAクラスタ対応

### DIFF
--- a/shared/config.nix
+++ b/shared/config.nix
@@ -75,6 +75,10 @@ let
       port = config.monitoring.k3sMetrics.apiServerPort;
     }
     {
+      name = "k3s.cluster.apiPort";
+      port = config.k3s.cluster.apiPort;
+    }
+    {
       name = "monitoring.loki";
       port = config.monitoring.loki.port;
     }
@@ -161,16 +165,8 @@ let
       message = "SSH port should not use the default port 22 for security reasons";
     }
     {
-      assertion =
-        config.k3s.desktop.enable
-        -> (config.k3s.desktop.role == "server" || config.k3s.desktop.role == "agent");
-      message = "k3s role must be either 'server' or 'agent'";
-    }
-    {
-      assertion =
-        config.k3s.desktop.role == "agent"
-        -> (builtins.hasAttr "serverAddr" config.k3s.desktop && config.k3s.desktop.serverAddr != "");
-      message = "k3s agent mode requires serverAddr to be set";
+      assertion = config.k3s.cluster.apiPort != config.k3s.cluster.apiBackendPort;
+      message = "k3s API port and backend port must be different (HAProxy frontend vs k3s backend)";
     }
   ];
 

--- a/shared/sections/infrastructure.nix
+++ b/shared/sections/infrastructure.nix
@@ -6,36 +6,70 @@
 */
 v: {
   k3s = {
-    # デスクトップ用k3s設定
+    # クラスタ共通設定
+    cluster = {
+      vip = v.assertIP "k3s.cluster.vip" "192.168.1.254";
+      apiPort = v.assertPort "k3s.cluster.apiPort" 6443;
+      apiBackendPort = v.assertPort "k3s.cluster.apiBackendPort" 6444;
+      serviceCIDR = v.assertCIDR "k3s.cluster.serviceCIDR" "192.168.128.0/24";
+      servicePool = v.assertString "k3s.cluster.servicePool" "192.168.128.100-192.168.128.200";
+      podCIDR = v.assertCIDR "k3s.cluster.podCIDR" "10.42.0.0/16";
+      bgp = {
+        localAS = v.assertPositiveInt "k3s.cluster.bgp.localAS" 65001;
+        peerAS = v.assertPositiveInt "k3s.cluster.bgp.peerAS" 65000;
+        peerAddress = v.assertIP "k3s.cluster.bgp.peerAddress" "192.168.1.1";
+      };
+    };
+
+    # 共通のk3sフラグ（Cilium用）
+    commonExtraFlags = [
+      "--flannel-backend=none"
+      "--disable-kube-proxy"
+      "--disable-network-policy"
+      "--disable=servicelb"
+      "--write-kubeconfig-mode=0644"
+    ];
+
+    # nixos-desktop: 初期化ノード
     desktop = {
       enable = v.assertBool "k3s.desktop.enable" true;
       role = v.assertEnum "k3s.desktop.role" "server" [
         "server"
         "agent"
       ];
-
-      # サーバー設定
       clusterInit = v.assertBool "k3s.desktop.clusterInit" true;
-
-      # 追加フラグ
+      keepalivedPriority = v.assertPositiveInt "k3s.desktop.keepalivedPriority" 150;
       extraFlags = [
-        "--flannel-backend=vxlan"
-        "--write-kubeconfig-mode=0644"
         "--node-ip=192.168.1.4"
-        # kubelet: cadvisorの統計収集間隔を延長（デフォルト10s → 30s）
         "--kubelet-arg=housekeeping-interval=30s"
-        # NetworkPolicyコントローラ（kube-router）を無効化
-        # 3秒ごとのmetrics tickループを停止させる
-        "--disable-network-policy"
       ];
     };
 
-    # 将来のhomeMachine用設定（現時点では無効）
+    # homeMachine: 参加ノード
     homeMachine = {
-      enable = v.assertBool "k3s.homeMachine.enable" false;
-      role = v.assertEnum "k3s.homeMachine.role" "agent" [
+      enable = v.assertBool "k3s.homeMachine.enable" true;
+      role = v.assertEnum "k3s.homeMachine.role" "server" [
         "server"
         "agent"
+      ];
+      keepalivedPriority = v.assertPositiveInt "k3s.homeMachine.keepalivedPriority" 100;
+      extraFlags = [
+        "--node-ip=192.168.1.3"
+        "--kubelet-arg=housekeeping-interval=30s"
+      ];
+    };
+
+    # g3pro: 参加ノード
+    g3pro = {
+      enable = v.assertBool "k3s.g3pro.enable" true;
+      role = v.assertEnum "k3s.g3pro.role" "server" [
+        "server"
+        "agent"
+      ];
+      keepalivedPriority = v.assertPositiveInt "k3s.g3pro.keepalivedPriority" 50;
+      extraFlags = [
+        "--node-ip=192.168.1.6"
+        "--kubelet-arg=housekeeping-interval=30s"
       ];
     };
   };

--- a/shared/sections/monitoring.nix
+++ b/shared/sections/monitoring.nix
@@ -40,7 +40,7 @@ v: {
     k3sMetrics = {
       kubeStateMetricsPort = v.assertPort "monitoring.k3sMetrics.kubeStateMetricsPort" 30080;
       kubeletPort = v.assertPort "monitoring.k3sMetrics.kubeletPort" 10250;
-      apiServerPort = v.assertPort "monitoring.k3sMetrics.apiServerPort" 6443;
+      apiServerPort = v.assertPort "monitoring.k3sMetrics.apiServerPort" 6444;
     };
 
     # Loki設定

--- a/systems/nixos/configurations/g3pro/default.nix
+++ b/systems/nixos/configurations/g3pro/default.nix
@@ -48,6 +48,9 @@ in
     ../../modules/services/mosh.nix
     ../../modules/services/deploy-user.nix
 
+    # Kubernetes
+    ../../modules/k3s.nix
+
     # 外部モジュール
     inputs.home-manager.nixosModules.home-manager
     inputs.sops-nix.nixosModules.sops

--- a/systems/nixos/configurations/homeMachine/default.nix
+++ b/systems/nixos/configurations/homeMachine/default.nix
@@ -50,6 +50,9 @@ in
     ../../modules/services/deploy-user.nix
     ../../modules/services/unified-cloudflare-tunnel.nix
 
+    # Kubernetes
+    ../../modules/k3s.nix
+
     # 外部モジュール
     inputs.attic.nixosModules.atticd
     inputs.home-manager.nixosModules.home-manager

--- a/systems/nixos/configurations/homeMachine/observability.nix
+++ b/systems/nixos/configurations/homeMachine/observability.nix
@@ -227,7 +227,7 @@ in
               }
             ];
           }
-          # k3s kubeletメトリクス
+          # k3s kubeletメトリクス（全ノード）
           {
             job_name = "k3s-kubelet";
             scheme = "https";
@@ -244,9 +244,25 @@ in
                   instance = cfg.networking.hosts.nixosDesktop.hostname;
                 };
               }
+              {
+                targets = [
+                  "192.168.1.3:${toString cfg.monitoring.k3sMetrics.kubeletPort}"
+                ];
+                labels = {
+                  instance = "${cfg.networking.hosts.nixos.hostname}.${cfg.networking.hosts.nixos.domain}";
+                };
+              }
+              {
+                targets = [
+                  "${cfg.networking.hosts.g3pro.ip}:${toString cfg.monitoring.k3sMetrics.kubeletPort}"
+                ];
+                labels = {
+                  instance = cfg.networking.hosts.g3pro.hostname;
+                };
+              }
             ];
           }
-          # k3s cAdvisorメトリクス（コンテナリソース使用量）
+          # k3s cAdvisorメトリクス（全ノード）
           {
             job_name = "k3s-cadvisor";
             scheme = "https";
@@ -264,9 +280,25 @@ in
                   instance = cfg.networking.hosts.nixosDesktop.hostname;
                 };
               }
+              {
+                targets = [
+                  "192.168.1.3:${toString cfg.monitoring.k3sMetrics.kubeletPort}"
+                ];
+                labels = {
+                  instance = "${cfg.networking.hosts.nixos.hostname}.${cfg.networking.hosts.nixos.domain}";
+                };
+              }
+              {
+                targets = [
+                  "${cfg.networking.hosts.g3pro.ip}:${toString cfg.monitoring.k3sMetrics.kubeletPort}"
+                ];
+                labels = {
+                  instance = cfg.networking.hosts.g3pro.hostname;
+                };
+              }
             ];
           }
-          # k3s API Serverメトリクス
+          # k3s API Serverメトリクス（全ノード）
           {
             job_name = "k3s-apiserver";
             scheme = "https";
@@ -277,10 +309,26 @@ in
             static_configs = [
               {
                 targets = [
-                  "${cfg.networking.hosts.nixosDesktop.ip}:${toString cfg.monitoring.k3sMetrics.apiServerPort}"
+                  "${cfg.networking.hosts.nixosDesktop.ip}:${toString cfg.k3s.cluster.apiBackendPort}"
                 ];
                 labels = {
                   instance = cfg.networking.hosts.nixosDesktop.hostname;
+                };
+              }
+              {
+                targets = [
+                  "192.168.1.3:${toString cfg.k3s.cluster.apiBackendPort}"
+                ];
+                labels = {
+                  instance = "${cfg.networking.hosts.nixos.hostname}.${cfg.networking.hosts.nixos.domain}";
+                };
+              }
+              {
+                targets = [
+                  "${cfg.networking.hosts.g3pro.ip}:${toString cfg.k3s.cluster.apiBackendPort}"
+                ];
+                labels = {
+                  instance = cfg.networking.hosts.g3pro.hostname;
                 };
               }
             ];

--- a/systems/nixos/modules/k3s.nix
+++ b/systems/nixos/modules/k3s.nix
@@ -1,34 +1,25 @@
 /*
-  k3s（Lightweight Kubernetes）設定モジュール
+  k3s HAクラスタ設定モジュール
 
-  このモジュールはk3sを使用した軽量Kubernetesクラスタを提供します。
+  このモジュールは3ノードHA構成のk3sクラスタを提供します。
 
-  機能:
-  - k3sサーバーモード: 完全なKubernetesクラスタをホスト
-  - k3sエージェントモード: 既存のクラスタにワーカーノードとして参加
-  - containerdコンテナランタイム（Dockerとは独立して動作）
-  - Flannelネットワーキング（VXLAN）
-  - CoreDNS（DNSサービス）
-  - Traefik Ingressコントローラー（デフォルト）
+  コンポーネント:
+  - k3s server: embedded etcd による HAクラスタ（3ノード）
+  - HAProxy: API Server ロードバランシング（:6443 → :6444）
+  - keepalived: VRRP による API Server VIP 管理
+  - Cilium: CNI + kube-proxy代替 + BGP Service LB（別途Helmでインストール）
+  - DRBD: カーネルレベルストレージレプリケーション（Piraeus Operator経由で管理）
 
-  提供する設定:
-  - services.k3s.enable: k3sサービスの有効化
-  - services.k3s.role: "server"または"agent"
-  - services.k3s.clusterInit: 初回クラスタ初期化フラグ
-  - services.k3s.extraFlags: 追加のk3sフラグ
+  ネットワーク設計:
+  - API Server VIP: 192.168.1.254 (keepalived VRRP)
+  - Service VIP: 192.168.128.0/24 (Cilium BGP → RouterOS ECMP)
+  - Pod CIDR: 10.42.0.0/16 (Cilium IPAM)
 
   使用方法:
-  1. shared/config.nixでkubernetes.k3s.desktop.enableをtrueに設定
-  2. roleを"server"または"agent"に設定
-  3. サーバーモードの場合、clusterInitをtrueに設定
-  4. nixos-rebuildでシステムを再構築
-  5. /etc/rancher/k3s/k3s.yamlにkubeconfigが生成される
-
-  注意事項:
-  - k3sはDockerとは独立したcontainerdを使用
-  - 初回起動時に/var/lib/rancher/k3s/server/node-tokenが生成される
-  - KUBECONFIG環境変数は自動的に/etc/rancher/k3s/k3s.yamlに設定される
-  - ファイアウォールで必要なポート（6443, 8472等）を自動的に開放
+  1. 各ホストのNixOS設定でこのモジュールをimport
+  2. shared/config.nixでk3s設定を定義
+  3. nixos-rebuild switchで適用
+  4. 初回はnixos-desktopから起動し、他ノードが順次join
 */
 {
   config,
@@ -46,16 +37,34 @@ let
       cfg.k3s.desktop
     else if config.networking.hostName == cfg.networking.hosts.nixos.hostname then
       cfg.k3s.homeMachine
+    else if config.networking.hostName == cfg.networking.hosts.g3pro.hostname then
+      cfg.k3s.g3pro
     else
       { enable = false; };
 
   enable = k3sConfig.enable or false;
   role = k3sConfig.role or "server";
   clusterInit = k3sConfig.clusterInit or false;
-  extraFlags = k3sConfig.extraFlags or [ ];
+  keepalivedPriority = k3sConfig.keepalivedPriority or 50;
 
-  # 監視用RBACマニフェスト: Prometheus外部スクレイプ用のServiceAccount・ClusterRole・トークン
-  # k3s起動時に自動デプロイされ、長寿命トークンで認証する
+  clusterCfg = cfg.k3s.cluster;
+
+  # k3sフラグを結合（共通 + ノード固有 + HA固有）
+  haFlags = [
+    "--https-listen-port=${toString clusterCfg.apiBackendPort}"
+    "--tls-san=${clusterCfg.vip}"
+  ];
+
+  serverAddrFlags =
+    if clusterInit then
+      [ ]
+    else
+      [ "--server=https://${clusterCfg.vip}:${toString clusterCfg.apiPort}" ];
+
+  allExtraFlags =
+    cfg.k3s.commonExtraFlags ++ haFlags ++ serverAddrFlags ++ (k3sConfig.extraFlags or [ ]);
+
+  # 監視用RBACマニフェスト
   monitoringRbacConfig = pkgs.writeText "monitoring-rbac.yaml" ''
     apiVersion: v1
     kind: Namespace
@@ -122,8 +131,7 @@ let
     type: kubernetes.io/service-account-token
   '';
 
-  # Traefik HelmChartConfig: Hub機能とGateway API providerを無効化し、
-  # 不要なCRD watchersを削減してAPI serverの負荷を軽減する
+  # Traefik HelmChartConfig
   traefikConfig = pkgs.writeText "traefik-config.yaml" ''
     apiVersion: helm.cattle.io/v1
     kind: HelmChartConfig
@@ -138,6 +146,57 @@ let
           kubernetesGateway:
             enabled: false
   '';
+
+  # HAProxy設定
+  haproxyConfig = ''
+    global
+        log /dev/log local0
+        maxconn 2048
+
+    defaults
+        log     global
+        mode    tcp
+        option  tcplog
+        timeout connect 5s
+        timeout client  30s
+        timeout server  30s
+
+    frontend k8s-api
+        bind *:${toString clusterCfg.apiPort}
+        default_backend k8s-api-servers
+
+    backend k8s-api-servers
+        option httpchk GET /healthz
+        http-check expect status 200
+        balance roundrobin
+        server nixos-desktop ${cfg.networking.hosts.nixosDesktop.ip}:${toString clusterCfg.apiBackendPort} check check-ssl verify none inter 3s fall 3 rise 2
+        server homemachine 192.168.1.3:${toString clusterCfg.apiBackendPort} check check-ssl verify none inter 3s fall 3 rise 2
+        server g3pro ${cfg.networking.hosts.g3pro.ip}:${toString clusterCfg.apiBackendPort} check check-ssl verify none inter 3s fall 3 rise 2
+  '';
+
+  # keepalivedのユニキャストピア（自分以外のノード）
+  allNodeIPs = [
+    cfg.networking.hosts.nixosDesktop.ip
+    "192.168.1.3"
+    cfg.networking.hosts.g3pro.ip
+  ];
+  myIP =
+    if config.networking.hostName == cfg.networking.hosts.nixosDesktop.hostname then
+      cfg.networking.hosts.nixosDesktop.ip
+    else if config.networking.hostName == cfg.networking.hosts.nixos.hostname then
+      "192.168.1.3"
+    else
+      cfg.networking.hosts.g3pro.ip;
+  unicastPeers = builtins.filter (ip: ip != myIP) allNodeIPs;
+
+  # ネットワークインターフェース（ホストごとに異なる可能性）
+  keepalivedInterface =
+    if config.networking.hostName == cfg.networking.hosts.nixosDesktop.hostname then
+      "enp2s0"
+    else if config.networking.hostName == cfg.networking.hosts.nixos.hostname then
+      cfg.networking.interfaces.primary
+    else
+      "enp1s0";
 in
 {
   config = lib.mkIf enable {
@@ -145,25 +204,50 @@ in
     services.k3s = {
       enable = true;
       inherit role;
-
-      # サーバーモード: クラスタ初期化
       clusterInit = lib.mkIf (role == "server") clusterInit;
+      # clusterInit でないノードはトークンが必要
+      # sops.secrets."k3s_token" は dotfiles-private 側で定義する
+      tokenFile = lib.mkIf (!clusterInit) "/run/secrets/k3s_token";
+      extraFlags = lib.strings.concatStringsSep " " allExtraFlags;
+    };
 
-      # 追加フラグ
-      extraFlags = lib.strings.concatStringsSep " " extraFlags;
+    # SOPS シークレット（クラスタトークン）はdotfiles-privateで定義
+    # sops.secrets."k3s_token" は各ホストの設定で sopsFile を指定する必要がある
+
+    # HAProxy: API Server ロードバランシング
+    services.haproxy = {
+      enable = true;
+      config = haproxyConfig;
+    };
+
+    # keepalived: VRRP VIP 管理
+    services.keepalived = {
+      enable = true;
+      vrrpScripts.check-haproxy = {
+        script = "${pkgs.procps}/bin/pgrep -x haproxy";
+        interval = 2;
+        weight = 2;
+      };
+      vrrpInstances.k8s-api = {
+        interface = keepalivedInterface;
+        virtualRouterId = 51;
+        priority = keepalivedPriority;
+        virtualIps = [ { addr = "${clusterCfg.vip}/24"; } ];
+        trackScripts = [ "check-haproxy" ];
+        inherit unicastPeers;
+      };
     };
 
     # k3sマニフェストディレクトリに設定ファイルを自動配置
-    # k3sが起動時に自動デプロイする
     systemd.tmpfiles.rules = [
       "L+ /var/lib/rancher/k3s/server/manifests/traefik-config.yaml - - - - ${traefikConfig}"
       "L+ /var/lib/rancher/k3s/server/manifests/monitoring-rbac.yaml - - - - ${monitoringRbacConfig}"
     ];
 
     # ghcr.io認証用のregistries.yamlを動的生成するsystemdサービス
-    # k3sのcontainerdレベルでレジストリ認証を設定し、ImagePullSecretを不要にする
-    # SOPSシークレット定義はargocd.nixモジュールで行う
-    systemd.services.k3s-registries = {
+    # argocd/ghcr_pat シークレットは dotfiles-private の argocd.nix で定義されるため、
+    # 初期化ノード（nixos-desktop）でのみ有効
+    systemd.services.k3s-registries = lib.mkIf clusterInit {
       description = "k3s Container Registry Authentication Setup";
       before = [ "k3s.service" ];
       after = [ "sops-nix.service" ];
@@ -203,8 +287,6 @@ in
 
           chmod 0600 /etc/rancher/k3s/registries.yaml
 
-          # k3sが既に稼働中の場合、registries.yamlの変更を反映するため再起動
-          # --no-block: before=k3s.serviceとの循環待ちを防止
           if systemctl is-active --quiet k3s.service; then
             systemctl restart --no-block k3s.service
           fi
@@ -217,29 +299,41 @@ in
       kubectl
       kubernetes-helm
       stern
+      drbd
     ];
 
     # ファイアウォール設定
     networking.firewall = {
-      # k3sサーバーモード用ポート
-      allowedTCPPorts = lib.mkIf (role == "server") [
-        6443 # Kubernetes API Server
+      allowedTCPPorts = [
+        clusterCfg.apiPort # HAProxy フロントエンド
+        clusterCfg.apiBackendPort # k3s API Server バックエンド
         10250 # Kubelet metrics
-        cfg.monitoring.k3sMetrics.kubeStateMetricsPort # kube-state-metrics NodePort
+        4240 # Cilium health check
+        4244 # Hubble
+        179 # BGP (Cilium ↔ RouterOS)
+        3366 # LINSTOR Controller
+        3367 # LINSTOR Satellite
       ];
 
-      # k3s内部通信用ポート範囲
       allowedTCPPortRanges = [
         {
           from = 2379;
           to = 2380;
         } # etcd
+        {
+          from = 7000;
+          to = 8000;
+        } # DRBD レプリケーション
       ];
 
-      # Flannel VXLAN
       allowedUDPPorts = [
-        8472 # Flannel VXLAN
+        8472 # Cilium VXLAN
       ];
+
+      # VRRP プロトコル（keepalived）
+      extraCommands = ''
+        iptables -A INPUT -p vrrp -j ACCEPT
+      '';
     };
 
     # KUBECONFIG環境変数の設定
@@ -247,11 +341,21 @@ in
       KUBECONFIG = "/etc/rancher/k3s/k3s.yaml";
     };
 
-    # k3s用のカーネルモジュール
+    # DRBD カーネルモジュール
+    boot.extraModulePackages = with config.boot.kernelPackages; [ drbd ];
     boot.kernelModules = [
       "br_netfilter"
       "overlay"
+      "drbd"
+      # Cilium 用
+      "ip_tables"
+      "xt_socket"
+      "xt_mark"
     ];
+    boot.blacklistedKernelModules = [ "drbd_transport_rdma" ];
+
+    # LVM thin provisioning（Piraeus/LINSTOR用）
+    services.lvm.boot.thin.enable = true;
 
     # カーネルパラメータ（Kubernetes推奨設定）
     boot.kernel.sysctl = {


### PR DESCRIPTION
## 概要
- infrastructure.nix: クラスタ共通設定(VIP, BGP, Ciliumフラグ)、homeMachine/g3pro設定追加
- k3s.nix: HAProxy + keepalived追加、Cilium用フラグ、DRBDカーネルモジュール、ファイアウォール拡張
- config.nix: ポートレジストリ更新、アサーション追加
- monitoring.nix: APIServerメトリクスポートを6444に変更
- g3pro/default.nix, homeMachine/default.nix: k3sモジュールimport追加
- observability.nix: Prometheus scrape targetを3ノード対応に拡張