### PR TITLE
k3s.nix修正: Cilium native routing、HAProxy tcp-check、ファイアウォール調整

### DIFF
--- a/systems/nixos/modules/k3s.nix
+++ b/systems/nixos/modules/k3s.nix
@@ -375,7 +375,12 @@ in
       ];
 
       # Cilium/k3s 関連のインターフェースを信頼
-      trustedInterfaces = [ "cilium_host" "cilium_net" "cilium_vxlan" "lxc+" ];
+      trustedInterfaces = [
+        "cilium_host"
+        "cilium_net"
+        "cilium_vxlan"
+        "lxc+"
+      ];
 
       # Cilium: rpfilter を loose に（Pod からの返信パケットが DROP されるのを防ぐ）
       checkReversePath = "loose";


### PR DESCRIPTION
## 概要
- Cilium: routingMode=native, ipv4NativeRoutingCIDR, autoDirectNodeRoutes, bpf.masquerade（tunnel modeではPod通信不可だった）
- HAProxy: option httpchk → option tcp-check（TCPモードでSSLバックエンドのヘルスチェック対応）
- ファイアウォール: checkReversePath=loose、Pod CIDR INPUT許可
- nftablesテーブル削除（iptablesバックエンドと混在していた不整合を修正）