### PR TITLE
Cloudflare TunnelのTraefik接続先をLB VIPに変更

### DIFF
--- a/shared/sections/infrastructure.nix
+++ b/shared/sections/infrastructure.nix
@@ -13,6 +13,7 @@ v: {
       apiBackendPort = v.assertPort "k3s.cluster.apiBackendPort" 6444;
       serviceCIDR = v.assertCIDR "k3s.cluster.serviceCIDR" "192.168.128.0/24";
       servicePool = v.assertString "k3s.cluster.servicePool" "192.168.128.100-192.168.128.200";
+      traefikVIP = v.assertIP "k3s.cluster.traefikVIP" "192.168.128.10";
       podCIDR = v.assertCIDR "k3s.cluster.podCIDR" "10.42.0.0/16";
       bgp = {
         localAS = v.assertPositiveInt "k3s.cluster.bgp.localAS" 65001;

--- a/systems/nixos/modules/k3s.nix
+++ b/systems/nixos/modules/k3s.nix
@@ -182,6 +182,9 @@ let
         providers:
           kubernetesGateway:
             enabled: false
+        service:
+          annotations:
+            io.cilium/lb-ipam-ips: "${clusterCfg.traefikVIP}"
   '';
 
   # HAProxy設定

--- a/systems/nixos/modules/services/desktop-cloudflare-tunnel.nix
+++ b/systems/nixos/modules/services/desktop-cloudflare-tunnel.nix
@@ -65,7 +65,7 @@ in
 
           # Google Calendar Bot - Zero Trust Accessで認証必要
           "${tunnelConfig.calendarBot.domain}" = {
-            service = "http://localhost:80"; # Traefik (k8s)
+            service = "http://${cfg.k3s.cluster.traefikVIP}:80"; # Traefik LB VIP (k8s)
             originRequest = {
               noTLSVerify = true;
               httpHostHeader = "${tunnelConfig.calendarBot.domain}";
@@ -75,7 +75,7 @@ in
 
           # mixi2 Bot - Webhook受信用
           "${tunnelConfig.mixi2Bot.domain}" = {
-            service = "http://localhost:80"; # Traefik (k8s)
+            service = "http://${cfg.k3s.cluster.traefikVIP}:80"; # Traefik LB VIP (k8s)
             originRequest = {
               noTLSVerify = true;
               httpHostHeader = "${tunnelConfig.mixi2Bot.domain}";
@@ -85,7 +85,7 @@ in
 
           # ArgoCD - Zero Trust Accessで認証必要
           "${tunnelConfig.argocd.domain}" = {
-            service = "http://localhost:80"; # Traefik
+            service = "http://${cfg.k3s.cluster.traefikVIP}:80"; # Traefik LB VIP
             originRequest = {
               noTLSVerify = true;
               httpHostHeader = "${tunnelConfig.argocd.domain}";


### PR DESCRIPTION
## 概要
- `k3s.cluster.traefikVIP`（192.168.128.10）をinfrastructure.nixに追加
- Traefik HelmChartConfigにCilium LB-IPAMアノテーション（`io.cilium/lb-ipam-ips`）を追加し、Traefik LB IPを固定化
- Cloudflare Tunnel の3エントリ（Google Calendar Bot, mixi2 Bot, ArgoCD）の接続先を`localhost:80`からTraefik LB VIPに変更
- HA構成でTraefik Podが別ノードで動作しても外部アクセスが正常に機能するようになる