### PR TITLE
DRBD 9カーネルモジュールのホスト側プリロードとカーネルバージョン統一

### DIFF
--- a/systems/nixos/modules/desktop.nix
+++ b/systems/nixos/modules/desktop.nix
@@ -63,6 +63,7 @@
     };
   };
 
-  # 最新カーネルの使用
-  boot.kernelPackages = pkgs.linuxPackages_latest;
+  # デフォルトカーネル（linuxPackages）を使用
+  # DRBD 9.2.x が linuxPackages_latest（6.19+）でビルド不可のため統一
+  boot.kernelPackages = pkgs.linuxPackages;
 }

--- a/systems/nixos/modules/k3s.nix
+++ b/systems/nixos/modules/k3s.nix
@@ -410,8 +410,6 @@ in
     };
 
     # カーネルモジュール
-    # DRBD はPiraeus Operator の Module Loader が管理する
-    # （nixpkgs の DRBD 9.2.16 は Linux 6.19+ で未対応のため、ホスト側ビルドは行わない）
     boot.kernelModules = [
       "br_netfilter"
       "overlay"
@@ -421,7 +419,15 @@ in
       "xt_mark"
       # LVM thin provisioning 用（LINSTOR/Piraeus）
       "dm-thin-pool"
+      # DRBD 9（Piraeus/LINSTOR 用）
+      # ホスト側でプリロードし、Piraeus の drbd-module-loader はビルドをスキップする
+      "drbd"
     ];
+
+    # DRBD 9 out-of-tree モジュール（Piraeus/LINSTOR 用）
+    # in-tree の DRBD 8.4.11 ではなく out-of-tree の 9.2.x を使用
+    # depmod は updates/ を kernel/ より優先するため、9.x が自動的に選択される
+    boot.extraModulePackages = with config.boot.kernelPackages; [ drbd ];
 
     # LVM thin provisioning（Piraeus/LINSTOR用）
     services.lvm.boot.thin.enable = true;


### PR DESCRIPTION
## 概要
- k3s.nix: `boot.extraModulePackages` に DRBD 9 を追加し、`boot.kernelModules` でブート時にプリロード
- desktop.nix: `linuxPackages_latest`（6.19）→ `linuxPackages`（6.18）に変更し全ノードのカーネルを統一

## 背景
Piraeus/LINSTORのSatellite Podが起動できない問題の対応。原因はNixOSに `/usr/src` が存在せず、drbd-module-loader がDRBD 9をコンテナ内ビルドできないこと。

NixOSホスト側でDRBD 9.2.xをプリロードすることで、drbd-module-loaderはビルドをスキップして `exit 0` する（`entry.sh` がDRBD既ロード済みを検出）。

カーネルを6.18に統一する理由: DRBD 9.2.16 が Linux 6.19 で `sockaddr_unsized` 型エラーによりビルド失敗するため。

## 関連変更
- k8s-apps側で `LinstorSatelliteConfiguration` CR の修正PRが別途必要