### PR TITLE
OpenSearch Dashboardsの接続先をk3s Traefik VIPに変更

### DIFF
--- a/systems/nixos/modules/services/desktop-cloudflare-tunnel.nix
+++ b/systems/nixos/modules/services/desktop-cloudflare-tunnel.nix
@@ -42,9 +42,9 @@ in
             };
           };
 
-          # OpenSearch Dashboards - Zero Trust Accessで認証必要
+          # OpenSearch Dashboards - k3s上で稼働、Traefik VIP経由
           "${cfg.opensearchDashboards.domain}" = {
-            service = "http://localhost:${toString cfg.opensearchDashboards.port}";
+            service = "http://${cfg.k3s.cluster.traefikVIP}:80";
             originRequest = {
               noTLSVerify = true;
               httpHostHeader = "${cfg.opensearchDashboards.domain}";


### PR DESCRIPTION
## 概要
- desktop-cloudflare-tunnel.nix: OpenSearch Dashboardsのbackendを `localhost:5601` から k3s Traefik VIP 経由に変更
- DNS・Terraform設定は変更不要（同じdesktop tunnelを維持）