### PR TITLE
deploy-rs checksを各プラットフォームのノードに限定してクロスビルド問題を修正

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -265,8 +265,18 @@
         };
       };
 
-      # deploy-rs checks
-      checks."x86_64-linux" = deploy-rs.lib.x86_64-linux.deployChecks self.deploy;
-      checks."aarch64-darwin" = deploy-rs.lib.aarch64-darwin.deployChecks self.deploy;
+      # deploy-rs checks（各プラットフォームに対応するノードのみに限定）
+      checks."x86_64-linux" = deploy-rs.lib.x86_64-linux.deployChecks {
+        nodes = nixpkgs.lib.filterAttrs (
+          name: _:
+          builtins.elem name [
+            "homeMachine"
+            "g3pro"
+          ]
+        ) self.deploy.nodes;
+      };
+      checks."aarch64-darwin" = deploy-rs.lib.aarch64-darwin.deployChecks {
+        nodes = nixpkgs.lib.filterAttrs (name: _: builtins.elem name [ "macmini" ]) self.deploy.nodes;
+      };
     };
 }


### PR DESCRIPTION
## 概要
- `deployChecks` に `self.deploy` 全体を渡していたため、x86_64-linux上でaarch64-darwinのderivationをビルドしようとして `nix flake check` が失敗していた問題を修正\n- `filterAttrs` で各プラットフォームに対応するノードのみに限定（x86_64-linux → homeMachine/g3pro、aarch64-darwin → macmini）\n\n## 関連Issue\n- Closes #494