### PR TITLE
Grafana の Cloudflare Tunnel 向け先を k3s Traefik VIP に切替

### DIFF
--- a/systems/nixos/modules/services/unified-cloudflare-tunnel.nix
+++ b/systems/nixos/modules/services/unified-cloudflare-tunnel.nix
@@ -38,10 +38,13 @@ in
             originRequest.noTLSVerify = true;
           };
 
-          # Grafana - Zero Trust Accessで認証必要
+          # Grafana - k3s上で稼働、Traefik VIP経由。Zero Trust Accessで認証必要
           "${cfg.monitoring.grafana.domain}" = {
-            service = "http://localhost:${toString cfg.monitoring.grafana.port}";
-            originRequest.noTLSVerify = true;
+            service = "http://${cfg.k3s.cluster.traefikVIP}";
+            originRequest = {
+              noTLSVerify = true;
+              httpHostHeader = cfg.monitoring.grafana.domain;
+            };
           };
 
           # Obsidian LiveSync - k3s上で稼働、Traefik VIP経由


### PR DESCRIPTION
## 概要

- k3s 上の HA Grafana に外部トラフィックを流すため、Cloudflare Tunnel の `grafana.shinbunbun.com` ingress を homeMachine `localhost:3000` から Traefik VIP `192.168.128.10` に切替
- `httpHostHeader` を明示して Traefik IngressRoute の `Host(\`grafana.shinbunbun.com\`)` マッチが確実に効くようにする
- NixOS 側 Grafana サービス自体は切り戻し容易性のため本 PR では残し、動作確認後の別 PR で `monitoring.grafana.enable = false` に変更予定