### PR TITLE
homeMachine: NixOS Grafana サービスを無効化

### DIFF
--- a/systems/nixos/configurations/homeMachine/observability.nix
+++ b/systems/nixos/configurations/homeMachine/observability.nix
@@ -364,8 +364,12 @@ in
       };
 
       # Grafana設定
+      # k3s 上の HA Grafana (k8s-apps/infrastructure/grafana) に移行済み。
+      # Cloudflare Tunnel も Traefik VIP に向き先を切替 (unified-cloudflare-tunnel.nix)。
+      # 切り戻しの容易性を保つため、port/domain/oauth 等の設定値と SOPS secret 参照は
+      # そのまま残す (enable = false の間は monitoring.nix 側 mkIf で未評価)。
       grafana = {
-        enable = true;
+        enable = false;
         port = cfg.monitoring.grafana.port;
         domain = cfg.monitoring.grafana.domain;
         secretKeyFile = config.sops.secrets."grafana/secret_key".path;


### PR DESCRIPTION
## 概要

- k3s 側 HA Grafana と Cloudflare Tunnel 切替が動作確認済みのため、homeMachine 上の NixOS `services.grafana` を無効化
- `monitoring.grafana.enable = true → false`、これに伴い port 3000 / systemd service / grafana パッケージインストールすべて `mkIf` 経由で自動無効化
- 切り戻し容易性のため、grafana ブロックの port/domain/oauth 等の設定値と SOPS secrets 定義はそのまま残す。`enable = true` に戻すだけで復活可能