### PR TITLE
cloudflared-k3s: Cloudflare Tunnel を k3s 内に移行 / Traefik 撤廃

### DIFF
--- a/devshell/default.nix
+++ b/devshell/default.nix
@@ -68,6 +68,7 @@ pkgs.mkShell {
       export TF_VAR_cloudflare_account_id=$(sops -d --extract '["cloudflare"]["account-id"]' secrets/cloudflare.yaml 2>/dev/null)
       export TF_VAR_home_tunnel_id=$(sops -d --extract '["cloudflare"]["tunnel-id"]' secrets/cloudflare.yaml 2>/dev/null)
       export TF_VAR_desktop_tunnel_id=$(sops -d --extract '["cloudflare"]["desktop-tunnel-id"]' secrets/cloudflare.yaml 2>/dev/null)
+      export TF_VAR_k3s_tunnel_id=$(sops -d --extract '["cloudflare"]["k3s-tunnel-id"]' secrets/cloudflare.yaml 2>/dev/null)
       export TF_VAR_identity_provider_id=$(sops -d --extract '["cloudflare"]["identity-provider-id"]' secrets/cloudflare.yaml 2>/dev/null)
 
       if [ -n "$CLOUDFLARE_API_TOKEN" ]; then

--- a/secrets/cloudflare.yaml
+++ b/secrets/cloudflare.yaml
@@ -11,6 +11,9 @@ cloudflare:
     identity-provider-id: ENC[AES256_GCM,data:NDeLwocDodv8zf7amc0P0kYbF+X7mVffAX0S/uk38Vvu2DsW,iv:pVUE65CtNGm2AfmrFHiEWQc5QIn7xuBdTRm1ID1LK/I=,tag:UaMTA2Kjph8z3iVaOgHo9Q==,type:str]
     r2-access-key-id: ENC[AES256_GCM,data:ldt00gbpMBXoBw2sxnkTpQYRMl2XLvaPTHb0AwC5fc4=,iv:vR9AF6cbyaONCW9uChqwGlk4EBfh/ACfZwEVLwiUc2A=,tag:RvjKI+ZEEyooxBiNAi/skA==,type:str]
     r2-secret-access-key: ENC[AES256_GCM,data:5cxg1SF1o4NeCWLT/UsapIo9NGfTnPYanoecxBLfORO4oaGbXZvHXAfc0hDaVbdXojc07+1DCnBfPgzQ6HGoXA==,iv:7Vyrq+bdnBmZaDvGXAFa/zg7SyeH5e2N+AUGU+4nVnQ=,tag:2pKYbHSjM5IM2Qyb+EPHow==,type:str]
+    k3s-account-tag: ENC[AES256_GCM,data:f3364rV8gaiUUY0/R6eGJOIB3dXZY5dmTYJ6MNaOYe8=,iv:xN+J/wY5zos+73ljJxz+tlwFZO7AJT7ZrrxtJuHzah4=,tag:T9klva5iBxIYws5XqZCuWg==,type:str]
+    k3s-tunnel-id: ENC[AES256_GCM,data:p53PO7bE/P5HrR25B3pLxRengYd3YbT3iCtHL/LSmWazp3rP,iv:fCeKezeg+E//QYZ4lRWtc3npEW1T0qCyqN9derVyYyk=,tag:UGlITzZ53nCzJWrKSiiXJQ==,type:str]
+    k3s-tunnel-secret: ENC[AES256_GCM,data:ze1lzjkbBW7NyNhnH7g0MAab9GOelPvPQYLdj+3u3iJ7/986P/TM7cGRFlc=,iv:RBzb3QbcHljiJQZA/Z0HScvQLXELy9OGvQ0eP+tULzA=,tag:n3Q0lUW4pRXI/Wjzn+Jv9w==,type:str]
 sops:
     age:
         - recipient: age1p057v4es63p6fef8usy67tkza7dj4xg326w5gm3c7rdthcd3xqlqps38z9
@@ -58,7 +61,7 @@ sops:
             ZlUvMGlFcWYrbjd1NHFmRkt2eUhRbWcKzsTocYktPNWfB0JkMMLilC2lMVmVAHUy
             07HPgCTJ/UKWvXG4Od9wYQ8e6k1d1xIqwMe7NIojk6ubeUJ2xDCAOA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-10-28T16:59:14Z"
-    mac: ENC[AES256_GCM,data:yy/Ap7cTsrkLuxG+Q/PzNaO0frrY2k4IlVsM0+AlABGbGukRVecDZJuk6pkcGJqpd/8dFMWNSgnSRL+Y3eEEqtKDLiRK4hCcbx2/uYtRXbxEiOc5sWCo6rLV3WO3raEw04UOlGbcCcRkjGJi3eBRLqbIrHVlm/0+c5rex51b8Mc=,iv:SxC0srsonuk9u269kV6aMspCWUNyAKCekfYD6r5mx2g=,tag:UosOOzSAOutTORPLkvlQjA==,type:str]
+    lastmodified: "2026-04-12T03:40:20Z"
+    mac: ENC[AES256_GCM,data:jNyxiGPQg6+KIpHmKwmInFqv/WIsLS4X/cBIc4TmcvcKE2HtDwAwpygaR8VNKpRVhA/qsf5/yzdbZNackXtLA9Pb6O0jybEOHT9fR4PiOpHkv4+tBL9AiRZzcZIwCmTOKhNBJ150v42B+7bIs4rbITp8mypmq7ZbZtYJkqhfJuk=,iv:uv+fU05s1Y0Wx13PMeBX8FizLCmuliGKHhOOoHzB+HM=,tag:vpNear/DcHBb396FVgGMlg==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.11.0

--- a/shared/sections/infrastructure.nix
+++ b/shared/sections/infrastructure.nix
@@ -28,6 +28,7 @@ v: {
       "--disable-kube-proxy"
       "--disable-network-policy"
       "--disable=servicelb"
+      "--disable=traefik"
       "--write-kubeconfig-mode=0644"
     ];
 

--- a/systems/nixos/modules/k3s.nix
+++ b/systems/nixos/modules/k3s.nix
@@ -176,25 +176,6 @@ let
             enabled: true
   '';
 
-  # Traefik HelmChartConfig
-  traefikConfig = pkgs.writeText "traefik-config.yaml" ''
-    apiVersion: helm.cattle.io/v1
-    kind: HelmChartConfig
-    metadata:
-      name: traefik
-      namespace: kube-system
-    spec:
-      valuesContent: |-
-        hub:
-          enabled: false
-        providers:
-          kubernetesGateway:
-            enabled: false
-        service:
-          annotations:
-            io.cilium/lb-ipam-ips: "${clusterCfg.traefikVIP}"
-  '';
-
   # HAProxy設定
   haproxyConfig = ''
     global
@@ -297,7 +278,6 @@ in
     # k3sマニフェストディレクトリに設定ファイルを自動配置
     systemd.tmpfiles.rules = [
       "L+ /var/lib/rancher/k3s/server/manifests/cilium-chart.yaml - - - - ${ciliumChart}"
-      "L+ /var/lib/rancher/k3s/server/manifests/traefik-config.yaml - - - - ${traefikConfig}"
       "L+ /var/lib/rancher/k3s/server/manifests/monitoring-rbac.yaml - - - - ${monitoringRbacConfig}"
     ];
 

--- a/systems/nixos/modules/services/argocd.nix
+++ b/systems/nixos/modules/services/argocd.nix
@@ -180,7 +180,6 @@ let
 
   # Nix store に保存するマニフェストファイル
   helmChartFile = pkgs.writeText "argocd-helmchart.yaml" helmChartManifest;
-  ingressRouteFile = pkgs.writeText "argocd-ingress.yaml" ingressRouteManifest;
 
   # HelmChart CRD マニフェスト
   helmChartManifest = ''
@@ -199,23 +198,6 @@ let
         ${builtins.replaceStrings [ "\n" ] [ "\n        " ] helmValues}
   '';
 
-  # Traefik IngressRoute マニフェスト
-  ingressRouteManifest = ''
-    apiVersion: traefik.io/v1alpha1
-    kind: IngressRoute
-    metadata:
-      name: argocd-server
-      namespace: ${argocdCfg.namespace}
-    spec:
-      entryPoints:
-        - web
-      routes:
-        - match: Host(`${argocdCfg.domain}`)
-          kind: Rule
-          services:
-            - name: argocd-server
-              port: 80
-  '';
 in
 {
 
@@ -293,10 +275,9 @@ in
           sleep 5
         done
 
-        # HelmChart CRD と IngressRoute を kubectl apply で適用
-        echo "Applying ArgoCD HelmChart and IngressRoute manifests..."
+        # HelmChart CRD を kubectl apply で適用
+        echo "Applying ArgoCD HelmChart manifest..."
         kubectl apply -f ${helmChartFile}
-        kubectl apply -f ${ingressRouteFile}
 
         # ArgoCD namespace が作成されるまで待機
         echo "Waiting for ArgoCD namespace..."

--- a/systems/nixos/modules/services/desktop-cloudflare-tunnel.nix
+++ b/systems/nixos/modules/services/desktop-cloudflare-tunnel.nix
@@ -1,15 +1,13 @@
 /*
-  nixos-desktop用Cloudflare Tunnel設定
+  nixos-desktop用Cloudflare Tunnel設定（ローカルサービス向け）
 
   機能:
-  - nixos-desktop専用のトンネル設定
-  - Cockpit、OpenSearch Dashboards、ArgoCDをCloudflare経由で公開
+  - nixos-desktop のローカルサービスへのトンネルアクセス
   - SOPS統合による認証情報管理
 
   注意:
-  - Cloudflare Zero Trust Accessの認証ポリシーは
-    別途Cloudflareダッシュボードまたは
-    Terraformで設定する必要があります
+  - k3s 上のアプリ（argocd, opensearch 等）は k3s 内の cloudflared で処理される
+  - このモジュールは localhost サービス専用
 */
 {
   config,
@@ -39,46 +37,6 @@ in
               noTLSVerify = true;
               httpHostHeader = "${tunnelConfig.cockpit.domain}";
               originServerName = "${tunnelConfig.cockpit.domain}";
-            };
-          };
-
-          # OpenSearch Dashboards - k3s上で稼働、Traefik VIP経由
-          "${cfg.opensearchDashboards.domain}" = {
-            service = "http://${cfg.k3s.cluster.traefikVIP}:80";
-            originRequest = {
-              noTLSVerify = true;
-              httpHostHeader = "${cfg.opensearchDashboards.domain}";
-              originServerName = "${cfg.opensearchDashboards.domain}";
-            };
-          };
-
-          # Google Calendar Bot - Zero Trust Accessで認証必要
-          "${tunnelConfig.calendarBot.domain}" = {
-            service = "http://${cfg.k3s.cluster.traefikVIP}:80"; # Traefik LB VIP (k8s)
-            originRequest = {
-              noTLSVerify = true;
-              httpHostHeader = "${tunnelConfig.calendarBot.domain}";
-              originServerName = "${tunnelConfig.calendarBot.domain}";
-            };
-          };
-
-          # mixi2 Bot - Webhook受信用
-          "${tunnelConfig.mixi2Bot.domain}" = {
-            service = "http://${cfg.k3s.cluster.traefikVIP}:80"; # Traefik LB VIP (k8s)
-            originRequest = {
-              noTLSVerify = true;
-              httpHostHeader = "${tunnelConfig.mixi2Bot.domain}";
-              originServerName = "${tunnelConfig.mixi2Bot.domain}";
-            };
-          };
-
-          # ArgoCD - Zero Trust Accessで認証必要
-          "${tunnelConfig.argocd.domain}" = {
-            service = "http://${cfg.k3s.cluster.traefikVIP}:80"; # Traefik LB VIP
-            originRequest = {
-              noTLSVerify = true;
-              httpHostHeader = "${tunnelConfig.argocd.domain}";
-              originServerName = "${tunnelConfig.argocd.domain}";
             };
           };
 

--- a/systems/nixos/modules/services/unified-cloudflare-tunnel.nix
+++ b/systems/nixos/modules/services/unified-cloudflare-tunnel.nix
@@ -1,15 +1,13 @@
 /*
-  統合Cloudflare Tunnel設定
+  Cloudflare Tunnel設定（homeMachine ローカルサービス向け）
 
   機能:
-  - すべてのサービスを1つのトンネルで管理
-  - 各サービスへのルーティング設定
+  - homeMachine のローカルサービスへのトンネルアクセス
   - SOPS統合による認証情報管理
 
   注意:
-  - Cloudflare Zero Trust Accessの認証ポリシーは
-    別途Cloudflareダッシュボードまたは
-    Terraformで設定する必要があります
+  - k3s 上のアプリ（grafana, authentik 等）は k3s 内の cloudflared で処理される
+  - このモジュールは localhost サービス専用
 */
 {
   config,
@@ -32,30 +30,6 @@ in
         credentialsFile = config.sops.templates."cloudflare/tunnel-credentials.json".path;
 
         ingress = {
-          # Authentik (認証プロバイダー) - k3s上で稼働、Traefik VIP経由
-          "auth.${domain}" = {
-            service = "http://${cfg.k3s.cluster.traefikVIP}";
-            originRequest.noTLSVerify = true;
-          };
-
-          # Grafana - k3s上で稼働、Traefik VIP経由。Zero Trust Accessで認証必要
-          "${cfg.monitoring.grafana.domain}" = {
-            service = "http://${cfg.k3s.cluster.traefikVIP}";
-            originRequest = {
-              noTLSVerify = true;
-              httpHostHeader = cfg.monitoring.grafana.domain;
-            };
-          };
-
-          # Obsidian LiveSync - k3s上で稼働、Traefik VIP経由
-          "private-obsidian.${domain}" = {
-            service = "http://${cfg.k3s.cluster.traefikVIP}";
-            originRequest = {
-              noTLSVerify = true;
-              httpHostHeader = "private-obsidian.${domain}";
-            };
-          };
-
           # Cockpit - Zero Trust Accessで認証必要
           "cockpit.${domain}" = {
             service = "http://localhost:${toString cfg.management.cockpit.port}";
@@ -76,14 +50,6 @@ in
               # 大きなファイルのアップロード用にタイムアウトを延長
               connectTimeout = "5m";
               noHappyEyeballs = true;
-            };
-          };
-
-          # peer-issuer (WireGuard peer動的発行API) - k3s上のAuthentik Embedded Outpost経由
-          "${cfg.peerIssuer.domain}" = {
-            service = "http://${cfg.k3s.cluster.traefikVIP}";
-            originRequest = {
-              noTLSVerify = true;
             };
           };
 

--- a/terraform/dns_records.tf
+++ b/terraform/dns_records.tf
@@ -6,11 +6,11 @@
 resource "cloudflare_dns_record" "authentik" {
   zone_id = var.cloudflare_zone_id
   name    = "auth.${local.base_domain}"
-  content = local.home_tunnel_endpoint
+  content = local.k3s_tunnel_endpoint
   type    = "CNAME"
   ttl     = 1
   proxied = true
-  comment = "Managed by Terraform - Authentik (IdP) via home-services tunnel"
+  comment = "Managed by Terraform - Authentik (IdP) via k3s-services tunnel"
 }
 
 # Grafana
@@ -28,11 +28,11 @@ resource "cloudflare_dns_record" "grafana" {
 resource "cloudflare_dns_record" "obsidian_livesync" {
   zone_id = var.cloudflare_zone_id
   name    = "private-obsidian.${local.base_domain}"
-  content = local.home_tunnel_endpoint
+  content = local.k3s_tunnel_endpoint
   type    = "CNAME"
   ttl     = 1
   proxied = true
-  comment = "Managed by Terraform - Obsidian LiveSync via home-services tunnel"
+  comment = "Managed by Terraform - Obsidian LiveSync via k3s-services tunnel"
 }
 
 # Cockpit (homeMachine)
@@ -61,11 +61,11 @@ resource "cloudflare_dns_record" "attic" {
 resource "cloudflare_dns_record" "peer_issuer" {
   zone_id = var.cloudflare_zone_id
   name    = "wg-lease.${local.base_domain}"
-  content = local.home_tunnel_endpoint
+  content = local.k3s_tunnel_endpoint
   type    = "CNAME"
   ttl     = 1
   proxied = true
-  comment = "Managed by Terraform - peer-issuer via home-services tunnel"
+  comment = "Managed by Terraform - peer-issuer via k3s-services tunnel"
 }
 
 # SSH for CI/CD deployment
@@ -98,33 +98,33 @@ resource "cloudflare_dns_record" "desktop_cockpit" {
 resource "cloudflare_dns_record" "opensearch_dashboards" {
   zone_id = var.cloudflare_zone_id
   name    = "opensearch.${local.base_domain}"
-  content = local.desktop_tunnel_endpoint
+  content = local.k3s_tunnel_endpoint
   type    = "CNAME"
   ttl     = 1
   proxied = true
-  comment = "Managed by Terraform - OpenSearch Dashboards via desktop-services tunnel"
+  comment = "Managed by Terraform - OpenSearch Dashboards via k3s-services tunnel"
 }
 
 # ArgoCD
 resource "cloudflare_dns_record" "argocd" {
   zone_id = var.cloudflare_zone_id
   name    = "argocd.${local.base_domain}"
-  content = local.desktop_tunnel_endpoint
+  content = local.k3s_tunnel_endpoint
   type    = "CNAME"
   ttl     = 1
   proxied = true
-  comment = "Managed by Terraform - ArgoCD via desktop-services tunnel"
+  comment = "Managed by Terraform - ArgoCD via k3s-services tunnel"
 }
 
 # Google Calendar Bot
 resource "cloudflare_dns_record" "calendar_bot" {
   zone_id = var.cloudflare_zone_id
   name    = "calendar-bot.${local.base_domain}"
-  content = local.desktop_tunnel_endpoint
+  content = local.k3s_tunnel_endpoint
   type    = "CNAME"
   ttl     = 1
   proxied = true
-  comment = "Managed by Terraform - Google Calendar Bot via desktop-services tunnel"
+  comment = "Managed by Terraform - Google Calendar Bot via k3s-services tunnel"
 }
 
 # Nextcloud
@@ -153,9 +153,9 @@ resource "cloudflare_dns_record" "immich" {
 resource "cloudflare_dns_record" "mixi2_bot" {
   zone_id = var.cloudflare_zone_id
   name    = "mixi2-bot.${local.base_domain}"
-  content = local.desktop_tunnel_endpoint
+  content = local.k3s_tunnel_endpoint
   type    = "CNAME"
   ttl     = 1
   proxied = true
-  comment = "Managed by Terraform - mixi2 Bot via desktop-services tunnel"
+  comment = "Managed by Terraform - mixi2 Bot via k3s-services tunnel"
 }

--- a/terraform/dns_records.tf
+++ b/terraform/dns_records.tf
@@ -17,11 +17,11 @@ resource "cloudflare_dns_record" "authentik" {
 resource "cloudflare_dns_record" "grafana" {
   zone_id = var.cloudflare_zone_id
   name    = "grafana.${local.base_domain}"
-  content = local.home_tunnel_endpoint
+  content = local.k3s_tunnel_endpoint
   type    = "CNAME"
   ttl     = 1
   proxied = true
-  comment = "Managed by Terraform - Grafana via home-services tunnel"
+  comment = "Managed by Terraform - Grafana via k3s-services tunnel"
 }
 
 # Obsidian LiveSync

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -42,4 +42,5 @@ locals {
   # トンネルへのCNAMEレコードは <tunnel-id>.cfargotunnel.com を指す
   home_tunnel_endpoint    = "${var.home_tunnel_id}.cfargotunnel.com"
   desktop_tunnel_endpoint = "${var.desktop_tunnel_id}.cfargotunnel.com"
+  k3s_tunnel_endpoint     = "${var.k3s_tunnel_id}.cfargotunnel.com"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -28,6 +28,11 @@ variable "desktop_tunnel_id" {
   type        = string
 }
 
+variable "k3s_tunnel_id" {
+  description = "Cloudflare Tunnel ID for k3s-services (k3s-internal cloudflared)"
+  type        = string
+}
+
 # 認証プロバイダー設定
 variable "identity_provider_id" {
   description = "Identity Provider ID for Cloudflare Access (Authentikなど)"


### PR DESCRIPTION
## 概要
- k3s アプリ向け Cloudflare Tunnel を k3s クラスタ内 Deployment に移行し、cloudflared が cluster DNS で直接 Service に接続する構成に変更
- 新規 `k3s-services` tunnel を作成、terraform 変数と SOPS secret を追加
- 8つの DNS CNAME (auth, grafana, private-obsidian, wg-lease, argocd, opensearch, calendar-bot, mixi2-bot) を k3s-services tunnel に切替
- 旧 NixOS cloudflared (home-services / desktop-services) から k3s アプリ向け ingress を削除し、localhost サービス専用に縮小
- Traefik を撤廃 (`--disable=traefik` 追加、HelmChartConfig 削除、ArgoCD IngressRoute 削除)

## 関連Issue
- Closes #572