### PR TITLE
monitoring.loki.host を追加し Fluent Bit を k3s LAN VIP 経由に切替 (Loki k3s 移行 Phase 3b)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -315,11 +315,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776125246,
-        "narHash": "sha256-tvfe4BBcC43DubHeVW6KFq7PbXzWG9dIf6MJ/zitjh0=",
+        "lastModified": 1776348449,
+        "narHash": "sha256-7KmvOHtQoVF87QONDFQSLVW/reG2I5fKKGO23C4ckOg=",
         "owner": "shinbunbun",
         "repo": "nixos-observability-config",
-        "rev": "442d9dfc8751717ac8f4ed91fec96e9739d5204f",
+        "rev": "f0c0c58b18f1ec0202964019c342907a5fc7488d",
         "type": "github"
       },
       "original": {

--- a/shared/sections/monitoring.nix
+++ b/shared/sections/monitoring.nix
@@ -30,6 +30,10 @@ v: {
 
     # Loki設定
     loki = {
+      # Fluent Bit クライアントの送信先ホスト。
+      # k3s 移行後は loki-lan Service (Cilium LB IPAM 固定 VIP) を指す。
+      # NixOS 側の旧 Loki サービス (homeMachine) は Phase 5 で停止予定。
+      host = v.assertString "monitoring.loki.host" "192.168.128.14";
       port = v.assertPort "monitoring.loki.port" 3100;
       retentionDays = v.assertPositiveInt "monitoring.loki.retentionDays" 30;
       ingestionRateLimit = v.assertPositiveInt "monitoring.loki.ingestionRateLimit" 52428800; # 50MB/s


### PR DESCRIPTION
## 概要

- `shared/sections/monitoring.nix`: `loki` セクションに `host` 追加 (デフォルト `192.168.128.14`)
- `nixos-observability-config` を Host 変数化後の版に更新 (`flake.lock`)
- homeMachine rebuild 後、Fluent Bit が k3s Loki (LAN VIP) に送信開始