### PR TITLE
homeMachine の Loki NixOS サービスを停止 (Loki k3s 移行 Phase 5a)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -295,11 +295,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776125199,
-        "narHash": "sha256-rWL29WVVI/a8CXuomlP0+PY1BVaX127+2bFlTqsTY+Q=",
+        "lastModified": 1776381333,
+        "narHash": "sha256-9VRe2KZFnLbXeOIdZL+Y10g2SH/R+nFapedcCnQV3yE=",
         "owner": "shinbunbun",
         "repo": "nixos-observability",
-        "rev": "8fa0da0c65ca0b8d230843de727f2feb3685b2bc",
+        "rev": "31109ce28bec5631dc85e76fc0699dc6f672c341",
         "type": "github"
       },
       "original": {

--- a/shared/sections/monitoring.nix
+++ b/shared/sections/monitoring.nix
@@ -3,12 +3,13 @@
 
   NixOS 側で使用する監視設定値を定義します：
   - Node Exporter: 各ホストのシステムメトリクス公開
-  - Loki: ログ集約
+  - Loki: Fluent Bit クライアントの送信先 (本体は k3s クラスタ)
   - Grafana: 外部 URL のみ保持（本体は k3s クラスタ）
-  - Alertmanager: k3s VMAlertmanager への LAN VIP 参照情報のみ保持（Loki ruler 用）
+  - Alertmanager: k3s VMAlertmanager への LAN VIP 参照情報のみ保持
 
   Prometheus / SNMP Exporter / k3sメトリクス設定は
   k3s クラスタの VictoriaMetrics スタック (k8s-apps) に移管済み。
+  Loki 本体も k3s クラスタ (k8s-apps/infrastructure/loki) に移管済み。
 */
 v: {
   monitoring = {
@@ -28,18 +29,11 @@ v: {
       vip = v.assertString "monitoring.alertmanager.vip" "192.168.128.13";
     };
 
-    # Loki設定
+    # Loki設定 (Fluent Bit クライアント参照用のみ、本体は k3s クラスタ)
     loki = {
-      # Fluent Bit クライアントの送信先ホスト。
-      # k3s 移行後は loki-lan Service (Cilium LB IPAM 固定 VIP) を指す。
-      # NixOS 側の旧 Loki サービス (homeMachine) は Phase 5 で停止予定。
+      # k3s 上の loki-lan Service (Cilium LB IPAM 固定 VIP)
       host = v.assertString "monitoring.loki.host" "192.168.128.14";
       port = v.assertPort "monitoring.loki.port" 3100;
-      retentionDays = v.assertPositiveInt "monitoring.loki.retentionDays" 30;
-      ingestionRateLimit = v.assertPositiveInt "monitoring.loki.ingestionRateLimit" 52428800; # 50MB/s
-      ingestionBurstSize = v.assertPositiveInt "monitoring.loki.ingestionBurstSize" 104857600; # 100MB
-      chunkTargetSize = v.assertPositiveInt "monitoring.loki.chunkTargetSize" 1572864;
-      dataDir = v.assertPath "monitoring.loki.dataDir" "/var/lib/loki";
     };
   };
 }

--- a/systems/nixos/configurations/homeMachine/default.nix
+++ b/systems/nixos/configurations/homeMachine/default.nix
@@ -54,7 +54,7 @@ in
     inputs.sops-nix.nixosModules.sops
     inputs.vscode-server.nixosModules.default
     inputs.nixos-observability.nixosModules.monitoring
-    inputs.nixos-observability.nixosModules.loki
+    # nixos-observability.nixosModules.loki は k3s に移行したため削除
     inputs.nixos-observability.nixosModules.fluentBit
   ];
 

--- a/systems/nixos/configurations/homeMachine/observability.nix
+++ b/systems/nixos/configurations/homeMachine/observability.nix
@@ -3,12 +3,12 @@
 
   このファイルは nixos-observability モジュールを使用した監視スタックの設定を定義します：
   - Node Exporter: システムメトリクス
-  - Loki: ログ集約
-  - Fluent Bit: ログ収集
+  - Fluent Bit: ログ収集 (k3s 上の Loki へ送信)
 
   Prometheus, Alertmanager, SNMP Exporter は k3s クラスタ (k8s-apps) の
   VictoriaMetrics スタックに移管済み。
   可視化（Grafana）も k3s クラスタ (k8s-apps/infrastructure/grafana) に移管済み。
+  Loki も k3s クラスタ (k8s-apps/infrastructure/loki) に移管済み。
 */
 {
   config,
@@ -36,20 +36,6 @@ in
       configFile = fluentBitConfigs.main;
       firewallPorts = [ cfg.fluentBit.syslogPort ]; # syslog UDP port
       openFirewall = true;
-    };
-
-    # Loki設定
-    loki = {
-      enable = true;
-      port = cfg.monitoring.loki.port;
-      dataDir = cfg.monitoring.loki.dataDir;
-      retentionDays = cfg.monitoring.loki.retentionDays;
-      ingestionRateLimit = cfg.monitoring.loki.ingestionRateLimit;
-      ingestionBurstSize = cfg.monitoring.loki.ingestionBurstSize;
-      chunkTargetSize = cfg.monitoring.loki.chunkTargetSize;
-      alertmanagerUrl = "http://${cfg.monitoring.alertmanager.vip}:${toString cfg.monitoring.alertmanager.port}";
-      rulesFile = inputs.nixos-observability-config.assets.lokiRules;
-      externalUrl = "https://${cfg.monitoring.grafana.domain}";
     };
 
     # Monitoring設定（Node Exporter のみ）


### PR DESCRIPTION
## 概要

- `homeMachine/default.nix`: `nixosModules.loki` の import をコメントアウト
- `homeMachine/observability.nix`: `services.observability.loki` ブロック削除
- `shared/sections/monitoring.nix`: NixOS 側 Loki 固有の設定 (retentionDays, ingestionRateLimit, ingestionBurstSize, chunkTargetSize, dataDir) を削除し、Fluent Bit クライアントが参照する host/port のみ残す
- `nixos-observability` を loki モジュール削除後の版に更新 (`flake.lock`)
- rebuild 適用後、systemd Loki サービスが停止 (`/var/lib/loki/` データは残存、retention 経過後に手動削除)