### PR TITLE
k3s: Cilium Hubble metrics / relay prometheus を有効化

### DIFF
--- a/systems/nixos/modules/k3s.nix
+++ b/systems/nixos/modules/k3s.nix
@@ -170,8 +170,22 @@ let
           enabled: true
         hubble:
           enabled: true
+          metrics:
+            enabled:
+              - dns
+              - drop
+              - tcp
+              - flow
+              - port-distribution
+              - icmp
+              - httpV2:exemplars=true;labelsContext=source_ip,source_namespace,source_workload,destination_ip,destination_namespace,destination_workload,traffic_direction
+            enableOpenMetrics: true
+            serviceMonitor:
+              enabled: false
           relay:
             enabled: true
+            prometheus:
+              enabled: true
           ui:
             enabled: true
   '';


### PR DESCRIPTION
## 概要
- bootstrap 用 `ciliumChart` の hubble values に `metrics.enabled` と `relay.prometheus.enabled` を追加
- k8s-apps 側 ArgoCD Application の Cilium values と一致させる

## 関連Issue
- Refs #568
