### PR TITLE
k3s: Cilium values に prometheus.enabled を追加

### DIFF
--- a/systems/nixos/modules/k3s.nix
+++ b/systems/nixos/modules/k3s.nix
@@ -168,6 +168,8 @@ let
               - "${clusterCfg.podCIDR}"
         bgpControlPlane:
           enabled: true
+        prometheus:
+          enabled: true
         hubble:
           enabled: true
           metrics:


### PR DESCRIPTION
## 概要
- bootstrap 用 `ciliumChart` の values に `prometheus.enabled: true` を追加（cilium-agent metrics port 9962 露出）
- k8s-apps 側の Cilium Application と values を一致させる

## 関連Issue
- Refs #568
