### PR TITLE
Hubble UI Cloudflare Access 公開: DNS + Zero Trust Application

### DIFF
--- a/terraform/access_policies.tf
+++ b/terraform/access_policies.tf
@@ -24,6 +24,24 @@ resource "cloudflare_zero_trust_access_application" "grafana" {
   }]
 }
 
+# Hubble UI - 認証必須（Hubble UI 自体は認証なしのため Cloudflare Access で保護）
+resource "cloudflare_zero_trust_access_application" "hubble" {
+  account_id                = var.cloudflare_account_id
+  name                      = "Hubble"
+  domain                    = local.home_services.hubble
+  type                      = "self_hosted"
+  session_duration          = "24h"
+  auto_redirect_to_identity = true
+  allowed_idps              = [var.identity_provider_id]
+  enable_binding_cookie     = false
+  options_preflight_bypass  = false
+
+  policies = [{
+    id         = cloudflare_zero_trust_access_policy.oidc_groups_allow.id
+    precedence = 1
+  }]
+}
+
 # Cockpit (homeMachine) - 認証必須
 resource "cloudflare_zero_trust_access_application" "home_cockpit" {
   account_id                = var.cloudflare_account_id

--- a/terraform/dns_records.tf
+++ b/terraform/dns_records.tf
@@ -24,6 +24,17 @@ resource "cloudflare_dns_record" "grafana" {
   comment = "Managed by Terraform - Grafana via k3s-services tunnel"
 }
 
+# Hubble UI (Cilium flow visualization)
+resource "cloudflare_dns_record" "hubble" {
+  zone_id = var.cloudflare_zone_id
+  name    = "hubble.${local.base_domain}"
+  content = local.k3s_tunnel_endpoint
+  type    = "CNAME"
+  ttl     = 1
+  proxied = true
+  comment = "Managed by Terraform - Hubble UI via k3s-services tunnel"
+}
+
 # Obsidian LiveSync
 resource "cloudflare_dns_record" "obsidian_livesync" {
   zone_id = var.cloudflare_zone_id

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -25,6 +25,7 @@ locals {
   home_services = {
     grafana = "grafana.${local.base_domain}"
     cockpit = "cockpit.${local.base_domain}"
+    hubble  = "hubble.${local.base_domain}"
   }
 
   # desktop-services (nixos-desktop) のドメイン


### PR DESCRIPTION
## 概要
- `terraform/main.tf`: `home_services.hubble` ドメイン定義追加
- `terraform/dns_records.tf`: `hubble.shinbunbun.com` CNAME → k3s-services tunnel
- `terraform/access_policies.tf`: Zero Trust Access Application 追加（Grafana と同じ `oidc_groups_allow` policy 使用）

Hubble UI は組込み認証なしのため Cloudflare Access での事前認証が必須。

マージ後は `cd terraform && terraform apply` を手動実行する。

## 関連Issue
- Refs #568
