### PR TITLE
k3s/cilium: 1.17.3 → 1.17.15 へ patch 昇格

### DIFF
--- a/shared/sections/infrastructure.nix
+++ b/shared/sections/infrastructure.nix
@@ -20,6 +20,7 @@ v: {
         peerAS = v.assertPositiveInt "k3s.cluster.bgp.peerAS" 65000;
         peerAddress = v.assertIP "k3s.cluster.bgp.peerAddress" "192.168.1.1";
       };
+      ciliumVersion = v.assertString "k3s.cluster.ciliumVersion" "1.17.15";
     };
 
     # 共通のk3sフラグ（Cilium用）

--- a/systems/nixos/modules/k3s.nix
+++ b/systems/nixos/modules/k3s.nix
@@ -150,7 +150,7 @@ let
     spec:
       repo: https://helm.cilium.io/
       chart: cilium
-      version: "1.17.3"
+      version: "${clusterCfg.ciliumVersion}"
       targetNamespace: kube-system
       bootstrap: true
       valuesContent: |-


### PR DESCRIPTION
## 概要
- k8s-apps 側の段階的アップグレード完了後に 1.19.3 で一括反映するため、本 PR は一旦クローズ
- ブランチ `feature/cilium-1.17.15` は後続の 1.18.9 / 1.19.3 コミットを追加して最終的に再 PR 予定