### PR TITLE
k3s/cilium: 1.17.3 → 1.19.3 へ同期

### DIFF
--- a/shared/sections/infrastructure.nix
+++ b/shared/sections/infrastructure.nix
@@ -20,6 +20,7 @@ v: {
         peerAS = v.assertPositiveInt "k3s.cluster.bgp.peerAS" 65000;
         peerAddress = v.assertIP "k3s.cluster.bgp.peerAddress" "192.168.1.1";
       };
+      ciliumVersion = v.assertString "k3s.cluster.ciliumVersion" "1.19.3";
     };
 
     # 共通のk3sフラグ（Cilium用）

--- a/systems/nixos/modules/k3s.nix
+++ b/systems/nixos/modules/k3s.nix
@@ -150,7 +150,7 @@ let
     spec:
       repo: https://helm.cilium.io/
       chart: cilium
-      version: "1.17.3"
+      version: "${clusterCfg.ciliumVersion}"
       targetNamespace: kube-system
       bootstrap: true
       valuesContent: |-


### PR DESCRIPTION
## 概要
- k3s bootstrap 用 HelmChart の Cilium バージョンを `1.17.3` → `1.19.3` に更新
- k8s-apps 側で段階的（1.17.15 → 1.18.9 → 1.19.3）に実施済のアップグレード結果に合わせて bootstrap 整合性を維持
- ハードコードを解消し `k3s.cluster.ciliumVersion` を `shared/sections/infrastructure.nix` に導入
- `nix fmt` / `nix flake check` / `nix build` で `version: "1.19.3"` 反映を確認済み