### PR TITLE
argocd: 各コンポーネントのメトリクス Service を有効化

### DIFF
--- a/systems/nixos/modules/services/argocd.nix
+++ b/systems/nixos/modules/services/argocd.nix
@@ -51,6 +51,19 @@ let
     # ArgoCD Server 設定
     server = {
       extraArgs = [ "--insecure" ]; # Traefik が TLS 終端するため
+      # Prometheus メトリクス Service (argocd-server-metrics :8083) を有効化
+      # VictoriaMetrics VMAgent が VMServiceScrape 経由で収集する
+      metrics.enabled = true;
+    };
+
+    # Application Controller のメトリクス Service (argocd-metrics :8082) を有効化
+    controller = {
+      metrics.enabled = true;
+    };
+
+    # ApplicationSet Controller のメトリクス (Service のメトリクス port 8080) を有効化
+    applicationSet = {
+      metrics.enabled = true;
     };
 
     # ArgoCD Config (argocd-cm ConfigMap)
@@ -118,6 +131,9 @@ let
 
     # repo-server に KSOPS プラグインと Age 鍵を追加
     repoServer = {
+      # repo-server のメトリクス (Service のメトリクス port 8084) を有効化
+      metrics.enabled = true;
+
       # KSOPS バイナリをインストールする init container
       initContainers = [
         {


### PR DESCRIPTION
## 概要
- `systems/nixos/modules/services/argocd.nix` の Helm values で `controller` / `server` / `repoServer` / `applicationSet` の `metrics.enabled = true` を追加
- これにより argocd namespace に以下のメトリクス Service が生成される
  - `argocd-application-controller-metrics` (:8082)
  - `argocd-server-metrics` (:8083)
  - `argocd-repo-server-metrics` (:8084)
  - `argocd-applicationset-controller-metrics` (:8080)
- 対応する `VMServiceScrape` と Grafana ダッシュボードは k8s-apps 側で別 PR として追加予定
- `notifications` は無効化構成のためスコープ外

## 動作確認
- `nix flake check --no-build` PASS
- `nix fmt` 差分なし
- `nix build .#nixosConfigurations.homeMachine.config.system.build.toplevel` 成功
