### PR TITLE
k3s: Cilium HelmChart addon を撤廃し ArgoCD 管理に統一

### DIFF
--- a/shared/sections/infrastructure.nix
+++ b/shared/sections/infrastructure.nix
@@ -20,7 +20,6 @@ v: {
         peerAS = v.assertPositiveInt "k3s.cluster.bgp.peerAS" 65000;
         peerAddress = v.assertIP "k3s.cluster.bgp.peerAddress" "192.168.1.1";
       };
-      ciliumVersion = v.assertString "k3s.cluster.ciliumVersion" "1.19.3";
     };
 
     # 共通のk3sフラグ（Cilium用）

--- a/systems/nixos/modules/k3s.nix
+++ b/systems/nixos/modules/k3s.nix
@@ -7,8 +7,15 @@
   - k3s server: embedded etcd による HAクラスタ（3ノード）
   - HAProxy: API Server ロードバランシング（:6443 → :6444）
   - keepalived: VRRP による API Server VIP 管理
-  - Cilium: CNI + kube-proxy代替 + BGP Service LB（別途Helmでインストール）
+  - Cilium: CNI + kube-proxy代替 + BGP Service LB（k8s-apps の ArgoCD Application で管理）
   - DRBD: カーネルレベルストレージレプリケーション（Piraeus Operator経由で管理）
+
+  新規クラスタ初期化時の Cilium bootstrap:
+  - ArgoCD は Cilium が動いていないと pod を schedule できないため、
+    クラスタ初回起動時のみ手動で Cilium をインストールする必要がある
+  - 手順: `helm install cilium cilium/cilium --version <ver> -n kube-system -f <values>`
+  - ArgoCD が起動したら application `cilium` が ServerSideApply で既存リソースを adopt し、
+    以降の管理は ArgoCD に引き継がれる
 
   ネットワーク設計:
   - API Server VIP: 192.168.1.254 (keepalived VRRP)
@@ -140,58 +147,6 @@ let
     type: kubernetes.io/service-account-token
   '';
 
-  # Cilium HelmChart（k3s が自動デプロイ）
-  ciliumChart = pkgs.writeText "cilium-chart.yaml" ''
-    apiVersion: helm.cattle.io/v1
-    kind: HelmChart
-    metadata:
-      name: cilium
-      namespace: kube-system
-    spec:
-      repo: https://helm.cilium.io/
-      chart: cilium
-      version: "${clusterCfg.ciliumVersion}"
-      targetNamespace: kube-system
-      bootstrap: true
-      valuesContent: |-
-        kubeProxyReplacement: true
-        k8sServiceHost: 127.0.0.1
-        k8sServicePort: ${toString clusterCfg.apiBackendPort}
-        routingMode: native
-        ipv4NativeRoutingCIDR: "${clusterCfg.podCIDR}"
-        autoDirectNodeRoutes: true
-        bpf:
-          masquerade: true
-        ipam:
-          operator:
-            clusterPoolIPv4PodCIDRList:
-              - "${clusterCfg.podCIDR}"
-        bgpControlPlane:
-          enabled: true
-        prometheus:
-          enabled: true
-        hubble:
-          enabled: true
-          metrics:
-            enabled:
-              - dns
-              - drop
-              - tcp
-              - flow
-              - port-distribution
-              - icmp
-              - httpV2:exemplars=true;labelsContext=source_ip,source_namespace,source_workload,destination_ip,destination_namespace,destination_workload,traffic_direction
-            enableOpenMetrics: true
-            serviceMonitor:
-              enabled: false
-          relay:
-            enabled: true
-            prometheus:
-              enabled: true
-          ui:
-            enabled: true
-  '';
-
   # HAProxy設定
   haproxyConfig = ''
     global
@@ -292,8 +247,9 @@ in
     };
 
     # k3sマニフェストディレクトリに設定ファイルを自動配置
+    # Cilium は ArgoCD で管理するため、ここでは配置しない
+    # （新規クラスタ初期化時のみ手動で helm install が必要。モジュール冒頭コメント参照）
     systemd.tmpfiles.rules = [
-      "L+ /var/lib/rancher/k3s/server/manifests/cilium-chart.yaml - - - - ${ciliumChart}"
       "L+ /var/lib/rancher/k3s/server/manifests/monitoring-rbac.yaml - - - - ${monitoringRbacConfig}"
     ];
 


### PR DESCRIPTION
## 概要

- k3s HelmChart addon による Cilium 配置を撤廃し、ArgoCD Application (`argocd/cilium`) での単独管理に統一
- `systems/nixos/modules/k3s.nix` から `ciliumChart` let binding と `systemd.tmpfiles.rules` の `cilium-chart.yaml` 配置を削除
- 未参照となった `k3s.cluster.ciliumVersion` を `shared/sections/infrastructure.nix` から削除
- モジュール冒頭コメントに、新規クラスタ初期化時の手動 bootstrap 手順を記載

## 背景

HelmChart addon と ArgoCD Application で Cilium を二重管理していたため、Cilium 1.18+ で追加された新規リソース (`Role/RoleBinding cilium-operator-ztunnel`、`Service hubble-metrics`、`Service hubble-relay-metrics`) を ArgoCD が先に作成 → helm-controller が adopt できず `helm upgrade` が失敗、`helm-install-cilium` Pod が CrashLoopBackOff → `KubePodCrashLooping` アラートが継続発火する事象が発生。

クラスタ側の即時対処として該当リソースに Helm metadata を付与し helm release を 1.19.3 に追いつかせたが、次回 Cilium バージョンアップ時に同じ問題が再発しうるため、HelmChart 配置自体を削除して二重管理を解消する。

## 動作確認

- `nix fmt`: 変更なし
- `nix flake check`: all checks passed
- `nix build .#nixosConfigurations.homeMachine.config.system.build.toplevel`: 成功
