### PR TITLE
terraform: Scanopy 用 Cloudflare Zero Trust Access Application を追加

### DIFF
--- a/terraform/access_policies.tf
+++ b/terraform/access_policies.tf
@@ -42,6 +42,24 @@ resource "cloudflare_zero_trust_access_application" "hubble" {
   }]
 }
 
+# Scanopy - 認証必須（Scanopy UI は Authentik OIDC 連携予定だが二重防御として Cloudflare Access でも保護）
+resource "cloudflare_zero_trust_access_application" "scanopy" {
+  account_id                = var.cloudflare_account_id
+  name                      = "Scanopy"
+  domain                    = local.home_services.scanopy
+  type                      = "self_hosted"
+  session_duration          = "24h"
+  auto_redirect_to_identity = true
+  allowed_idps              = [var.identity_provider_id]
+  enable_binding_cookie     = false
+  options_preflight_bypass  = false
+
+  policies = [{
+    id         = cloudflare_zero_trust_access_policy.oidc_groups_allow.id
+    precedence = 1
+  }]
+}
+
 # Cockpit (homeMachine) - 認証必須
 resource "cloudflare_zero_trust_access_application" "home_cockpit" {
   account_id                = var.cloudflare_account_id

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -26,6 +26,7 @@ locals {
     grafana = "grafana.${local.base_domain}"
     cockpit = "cockpit.${local.base_domain}"
     hubble  = "hubble.${local.base_domain}"
+    scanopy = "scanopy.${local.base_domain}"
   }
 
   # desktop-services (nixos-desktop) のドメイン


### PR DESCRIPTION
## 概要
`scanopy.shinbunbun.com` が Cloudflare Access で保護されていなかった (grafana / hubble / cockpit 等は保護済) ため、同じ `oidc_groups_allow` ポリシー + Authentik IdP 連携で保護する。

- `main.tf` : `local.home_services.scanopy` を追加
- `access_policies.tf` : `cloudflare_zero_trust_access_application.scanopy` を追加
  - session_duration 24h / auto_redirect_to_identity / allowed_idps = Authentik

Scanopy 側の Authentik OIDC (PR #617 済) と併せて二重防御構成。