### PR TITLE
fix(terraform): Scanopy OIDC Provider の redirect_uri を修正

### DIFF
--- a/terraform/authentik_providers.tf
+++ b/terraform/authentik_providers.tf
@@ -221,7 +221,7 @@ resource "authentik_provider_oauth2" "scanopy" {
   client_secret      = var.scanopy_oauth_client_secret
   signing_key        = data.authentik_certificate_key_pair.es256_jwt_signing.id
   allowed_redirect_uris = [
-    { matching_mode = "strict", url = "https://scanopy.shinbunbun.com/oauth/callback" },
+    { matching_mode = "strict", url = "https://scanopy.shinbunbun.com/api/auth/oidc/authentik/callback" },
   ]
   property_mappings = [
     data.authentik_property_mapping_provider_scope.openid.id,


### PR DESCRIPTION
## 概要
Scanopy UI で Authentik SSO 実行時に:
```
The request fails due to a missing, invalid, or mismatching redirection URI (redirect_uri).
```
と出る問題の修正。

- Scanopy の実 OIDC callback URL は `/api/auth/oidc/{slug}/callback` 形式 ([公式 docs](https://scanopy.net/docs/oidc/))
- `slug = "authentik"` なので正しい redirect_uri は `https://scanopy.shinbunbun.com/api/auth/oidc/authentik/callback`
- 当初 `/oauth/callback` と誤って設定していたため Authentik 側で mismatch

マージ後 `terraform apply` で Authentik の allowed_redirect_uris が更新され、SSO 完了する想定。