### PR TITLE
fail2ban: WireGuardサブネット(10.66.66.0/24)をignoreNetworksに追加

### DIFF
--- a/shared/sections/networking.nix
+++ b/shared/sections/networking.nix
@@ -63,6 +63,7 @@ v: {
     ignoreNetworks = v.assertListOf "fail2ban.ignoreNetworks" [
       "192.168.11.0/24"
       "163.143.0.0/16"
+      "10.66.66.0/24" # WireGuardクライアントを除外（fail2banループ防止）
     ] v.assertCIDR;
   };
 


### PR DESCRIPTION
## 概要
- `shared/sections/networking.nix` の `fail2ban.ignoreNetworks` に WireGuard サブネット `10.66.66.0/24` を追加
- `allowedNetworks` では既に許可していたが `fail2ban.ignoreNetworks` に入っておらず、WireGuard クライアント IP (`10.66.66.2`) が SSH 失敗試行の蓄積で fail2ban に ban されるケースがあったため解消

## 動作確認
- `nix flake check` / `nix fmt` / `nix build .#nixosConfigurations.homeMachine.config.system.build.toplevel` 成功
- `nix eval .#nixosConfigurations.homeMachine.config.services.fail2ban.ignoreIP` → `[ "192.168.11.0/24" "163.143.0.0/16" "10.66.66.0/24" ]` を確認
