### PR TITLE
flake: nixos-observability-config を更新 (macOS false-positive error ドロップ)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -315,11 +315,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776586944,
-        "narHash": "sha256-Rsp0Om6x9ZPMXlBaoJDs+pS86G3AzP8nDsZX87LT/OI=",
+        "lastModified": 1776686365,
+        "narHash": "sha256-/P2K4ZfyO5JcavKI3SMCbSSELS7feqAraipz1aYtVXk=",
         "owner": "shinbunbun",
         "repo": "nixos-observability-config",
-        "rev": "099b768fb852138b3ca8484d2c2ba38051d84148",
+        "rev": "db03d2c6c53aa520b72506240fbcf435d01109fa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## 概要

- `nixos-observability-config` を更新し、deploy-rs / github-runner 実行時に `MacOSErrorLogDetected` が誤発報していた 2 パターンを Fluent Bit 側でドロップ
  - `networkd_settings_init notify_register_check ... status 8 token -1`
  - `All kCFPreferencesCurrentUser domains ... volatile, because homeDirPath starts with /var/empty`
- 真のエラーは引き続き level=error で検知される
