### PR TITLE
shared: Fluent Bit から Vector への Forward 先設定を追加

### DIFF
--- a/shared/config.nix
+++ b/shared/config.nix
@@ -83,6 +83,10 @@ let
       port = config.fluentBit.syslogPort;
     }
     {
+      name = "fluentBit.vector";
+      port = config.fluentBit.vectorPort;
+    }
+    {
       name = "attic";
       port = config.attic.port;
     }

--- a/shared/sections/infrastructure.nix
+++ b/shared/sections/infrastructure.nix
@@ -203,5 +203,11 @@ v: {
     opensearchHost = v.assertIP "fluentBit.opensearchHost" "192.168.1.4";
     opensearchPort = v.assertPort "fluentBit.opensearchPort" 9200;
     k3sPodLogDir = v.assertPath "fluentBit.k3sPodLogDir" "/var/log/pods";
+    # Phase 2e で OpenSearch を撤去する際に false にして OUTPUT を無効化する
+    enableOpenSearch = v.assertBool "fluentBit.enableOpenSearch" true;
+    # Vector (log-archiver-vector) の Fluent Forward エンドポイント。
+    # k3s 上の Cilium LB IPAM で固定 VIP (LAN) が割当てられている。
+    vectorHost = v.assertIP "fluentBit.vectorHost" "192.168.128.17";
+    vectorPort = v.assertPort "fluentBit.vectorPort" 24224;
   };
 }


### PR DESCRIPTION
## 概要

Phase 2b (ログ解析基盤) 対応。Fluent Bit から k3s 上の log-archiver-vector (Cilium LB VIP 192.168.128.17:24224) へ Fluent Forward プロトコルで転送するための shared 設定値を追加する。

- `fluentBit.vectorHost` / `vectorPort`: Vector の Forward エンドポイント
- `fluentBit.enableOpenSearch`: Phase 2e で false にして OpenSearch 出力を切るための互換オプション (デフォルト true)
- `portRegistry` に `fluentBit.vector` を追加 (ポート衝突検知)

generator 側の実装 (OUTPUT 追加) は nixos-observability-config の別 PR で対応する。
