### PR TITLE
home/development-tools: kubectl-cnpg プラグインを追加

### DIFF
--- a/home/modules/development/development-tools.nix
+++ b/home/modules/development/development-tools.nix
@@ -4,6 +4,9 @@
   このモジュールは開発に必要なツールを提供します：
   - cocoapods: iOS/macOSアプリ開発用のパッケージマネージャー
   - terraform: インフラストラクチャを code として管理するツール
+  - pnpm: Node.js パッケージマネージャー
+  - kubectl-cnpg: CloudNativePG (k3s 上の PostgreSQL Cluster) 管理用 kubectl プラグイン
+    (`kubectl cnpg restart`, `kubectl cnpg status`, `kubectl cnpg backup` 等)
 
   モバイルアプリ開発やインフラ管理のツールが含まれます。
 */
@@ -14,6 +17,7 @@
     [
       terraform
       pnpm
+      kubectl-cnpg
     ]
     ++ lib.optionals stdenv.isDarwin [
       cocoapods


### PR DESCRIPTION
## 概要

- `pkgs.kubectl-cnpg` (v1.29.0、CNPG Operator v1.29 系と整合) を `home/modules/development/development-tools.nix` に追加
- `kubectl cnpg restart` `kubectl cnpg status` `kubectl cnpg backup` など CloudNativePG 管理コマンドが使えるようになる

## 契機

k8s-apps の MinIO→Garage 移行 PR-2c で、`ObjectStore` CR 更新後の barman-cloud sidecar を rolling restart するときに CNPG プラグインが必要になった。

## 検証

- `nix fmt`: 0 changed
- `nix flake check --no-build`: all checks passed
- マージ後 `home-manager switch` で `kubectl cnpg` が PATH に入ることを確認