### PR TITLE
flake: nixos-observability-config を log_type=k8s-pods 対応版に更新

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -315,11 +315,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776818287,
-        "narHash": "sha256-F4ioYqCRoUDc68aK51flWAx6z9ZwkHhrMEhP01SAAEQ=",
+        "lastModified": 1776907157,
+        "narHash": "sha256-oOUdHOvRWCiQKfuQERJ5ZxNncUdLHOIsHBopkfUvpLM=",
         "owner": "shinbunbun",
         "repo": "nixos-observability-config",
-        "rev": "6ad023c4ce24891e5d4e27dcf9852f0fea92399a",
+        "rev": "26c7a530ec78af856f7ee0f3a78baaa8672461fa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## 概要

Phase 2c リアーキ連動。k3s pods 経路の Fluent Bit FILTER に `log_type=k8s-pods` を付与する変更を取り込み、Vector aws_s3 sink の key_prefix template (`{{ log_type }}`) が全 source で解決するようにする。

shinbunbun/nixos-observability-config#45 参照。
