### PR TITLE
refactor(fluent-bit): enableOpenSearch をデフォルト false に切り替え

### DIFF
--- a/shared/sections/infrastructure.nix
+++ b/shared/sections/infrastructure.nix
@@ -203,8 +203,8 @@ v: {
     opensearchHost = v.assertIP "fluentBit.opensearchHost" "192.168.1.4";
     opensearchPort = v.assertPort "fluentBit.opensearchPort" 9200;
     k3sPodLogDir = v.assertPath "fluentBit.k3sPodLogDir" "/var/log/pods";
-    # Phase 2e で OpenSearch を撤去する際に false にして OUTPUT を無効化する
-    enableOpenSearch = v.assertBool "fluentBit.enableOpenSearch" true;
+    # OpenSearch 撤去 Phase B: default false で OUTPUT を無効化済み。本体撤去後に option ごと削除予定。
+    enableOpenSearch = v.assertBool "fluentBit.enableOpenSearch" false;
     # Vector (log-archiver-vector) の Fluent Forward エンドポイント。
     # k3s 上の Cilium LB IPAM で固定 VIP (LAN) が割当てられている。
     vectorHost = v.assertIP "fluentBit.vectorHost" "192.168.128.17";


### PR DESCRIPTION
## 概要
- `shared/sections/infrastructure.nix` の `fluentBit.enableOpenSearch` を default `false` に変更
- Fluent Bit → OpenSearch OUTPUT を全ホスト (Linux: nixos-desktop/homeMachine/g3pro, Darwin: macbook/macmini) で停止
- DuckDB/Parquet (Garage S3) パイプラインを唯一の長期ログ保存経路にする
- Loki / Vector (log-archiver-vector) への出力は維持

## 背景
OpenSearch 撤去の第2フェーズ。本体削除前の観察期間用で、revert すれば復旧可能。マージ後に dotfiles-private 側で flake.lock を更新し、各ホストへ deploy する。

## 動作確認
- `nix flake check`: all checks passed
- `nix build .#nixosConfigurations.homeMachine.config.system.build.toplevel`: OK