### PR TITLE
refactor: shared/config から OpenSearch 設定を削除 + flake input 更新

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -295,11 +295,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776381333,
-        "narHash": "sha256-9VRe2KZFnLbXeOIdZL+Y10g2SH/R+nFapedcCnQV3yE=",
+        "lastModified": 1777094382,
+        "narHash": "sha256-L2QkmL6D1m2ylKu8RdhLx3ALhReDtdaNkiFmCNoI1rU=",
         "owner": "shinbunbun",
         "repo": "nixos-observability",
-        "rev": "31109ce28bec5631dc85e76fc0699dc6f672c341",
+        "rev": "2fe2014b1fd526b9ef79aef8895fe8dedeb0a119",
         "type": "github"
       },
       "original": {
@@ -315,11 +315,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776907157,
-        "narHash": "sha256-oOUdHOvRWCiQKfuQERJ5ZxNncUdLHOIsHBopkfUvpLM=",
+        "lastModified": 1777094401,
+        "narHash": "sha256-KiS/30qRTu1ZWCX3iHeEV9igambnjysR4lKOCo92+QE=",
         "owner": "shinbunbun",
         "repo": "nixos-observability-config",
-        "rev": "26c7a530ec78af856f7ee0f3a78baaa8672461fa",
+        "rev": "490b92e180ed05d44179459d37db8e3f7e29a7d8",
         "type": "github"
       },
       "original": {

--- a/shared/config.nix
+++ b/shared/config.nix
@@ -63,18 +63,6 @@ let
       port = config.management.cockpit.port;
     }
     {
-      name = "opensearch";
-      port = config.opensearch.port;
-    }
-    {
-      name = "opensearch.transport";
-      port = config.opensearch.transportPort;
-    }
-    {
-      name = "opensearchDashboards";
-      port = config.opensearchDashboards.port;
-    }
-    {
       name = "fluentBit";
       port = config.fluentBit.port;
     }

--- a/shared/sections/infrastructure.nix
+++ b/shared/sections/infrastructure.nix
@@ -1,8 +1,7 @@
 /*
   インフラストラクチャ設定セクション
 
-  k3s、NFS、Atticバイナリキャッシュ、peer-issuer、
-  OpenSearch、OpenSearch Dashboards、Fluent Bitの設定を定義します。
+  k3s、NFS、Atticバイナリキャッシュ、peer-issuer、Fluent Bitの設定を定義します。
 */
 v: {
   k3s = {
@@ -164,47 +163,10 @@ v: {
     stateDirectory = v.assertPath "peerIssuer.stateDirectory" "/var/lib/peer-issuer";
   };
 
-  opensearch = {
-    # サーバー設定
-    port = v.assertPort "opensearch.port" 9200;
-    transportPort = v.assertPort "opensearch.transportPort" 9300;
-    dataDir = v.assertPath "opensearch.dataDir" "/var/lib/opensearch";
-
-    # メモリ設定（ヒープ4GB + Off-heap用4GB = 合計8GB）
-    heapSize = v.assertString "opensearch.heapSize" "4g";
-    maxMemory = v.assertPositiveInt "opensearch.maxMemory" 8589934592; # 4GB heap + 4GB off-heap = 8GB
-
-    # クラスター設定
-    clusterName = v.assertString "opensearch.clusterName" "shinbunbun-logs";
-    nodeName = v.assertString "opensearch.nodeName" "nixos-desktop";
-
-    # インデックス設定
-    numberOfShards = v.assertPositiveInt "opensearch.numberOfShards" 1; # 単一ノードのため
-    numberOfReplicas = v.assertNonNegativeInt "opensearch.numberOfReplicas" 0; # レプリカ不要
-
-    # セキュリティ設定
-    enableSecurity = v.assertBool "opensearch.enableSecurity" true;
-    allowedNetworks = v.assertListOf "opensearch.allowedNetworks" [
-      "192.168.1.0/24"
-      "192.168.11.0/24"
-      "10.66.66.0/24" # WireGuard
-    ] v.assertCIDR;
-  };
-
-  opensearchDashboards = {
-    port = v.assertPort "opensearchDashboards.port" 5601;
-    domain = v.assertString "opensearchDashboards.domain" "opensearch.shinbunbun.com";
-    opensearchUrl = v.assertString "opensearchDashboards.opensearchUrl" "http://192.168.1.4:9200";
-  };
-
   fluentBit = {
     port = v.assertPort "fluentBit.port" 2020;
     syslogPort = v.assertPort "fluentBit.syslogPort" 514;
-    opensearchHost = v.assertIP "fluentBit.opensearchHost" "192.168.1.4";
-    opensearchPort = v.assertPort "fluentBit.opensearchPort" 9200;
     k3sPodLogDir = v.assertPath "fluentBit.k3sPodLogDir" "/var/log/pods";
-    # OpenSearch 撤去 Phase B: default false で OUTPUT を無効化済み。本体撤去後に option ごと削除予定。
-    enableOpenSearch = v.assertBool "fluentBit.enableOpenSearch" false;
     # Vector (log-archiver-vector) の Fluent Forward エンドポイント。
     # k3s 上の Cilium LB IPAM で固定 VIP (LAN) が割当てられている。
     vectorHost = v.assertIP "fluentBit.vectorHost" "192.168.128.17";

--- a/systems/darwin/modules/fluent-bit.nix
+++ b/systems/darwin/modules/fluent-bit.nix
@@ -8,7 +8,7 @@
   1. macos-log-stream: macOS Unified Logging Systemの log stream 出力をファイルに書き出す
      - 起動時に前回停止時刻からのログをキャッチアップ（欠落ゼロ設計）
      - リアルタイムストリーミングで /var/log/macos-unified.log にアペンド
-  2. fluent-bit: /var/log/macos-unified.log を tail input で読み取り、Loki/OpenSearchに転送
+  2. fluent-bit: /var/log/macos-unified.log を tail input で読み取り、Loki / Vector (k3s) に転送
   3. macos-log-rotate: 日次ログローテーション（3日保持、gzip圧縮）
 */
 {

--- a/systems/nixos/configurations/g3pro/observability.nix
+++ b/systems/nixos/configurations/g3pro/observability.nix
@@ -3,7 +3,7 @@
 
   このファイルはg3proの監視設定を定義します：
   - Node Exporter: システムメトリクスの公開（homeMachineのPrometheusがスクレイプ）
-  - Fluent Bit: systemd-journalログをhomeMachineのLoki/OpenSearchへ転送
+  - Fluent Bit: systemd-journalログを Loki / Vector (k3s) へ転送
 
   Fluent Bitは nixos-observability-config の generator を使用し、
   homeMachineと同じフォーマットでログを転送します。
@@ -52,7 +52,7 @@ in
   };
 
   # Fluent Bit設定（nixos-observability モジュール経由）
-  # systemd-journal → Loki + OpenSearch へログ転送
+  # systemd-journal → Loki + Vector (k3s) へログ転送
   # syslog入力も含まれるが、RouterOSからの送信がないためidle
   services.observability.fluentBit = {
     enable = true;

--- a/systems/nixos/modules/services/desktop-cloudflare-tunnel.nix
+++ b/systems/nixos/modules/services/desktop-cloudflare-tunnel.nix
@@ -6,7 +6,7 @@
   - SOPS統合による認証情報管理
 
   注意:
-  - k3s 上のアプリ（argocd, opensearch 等）は k3s 内の cloudflared で処理される
+  - k3s 上のアプリ（argocd 等）は k3s 内の cloudflared で処理される
   - このモジュールは localhost サービス専用
 */
 {


### PR DESCRIPTION
## 概要
OpenSearch 撤去 Phase F1。共有設定からオプションとポート定義を削除し、コメントを整理。あわせて nixos-observability / nixos-observability-config の flake input を OpenSearch 撤去版に更新。

## 変更
- `shared/sections/infrastructure.nix`: `opensearch` / `opensearchDashboards` ブロック削除、`fluentBit` 内の `opensearchHost` / `opensearchPort` / `enableOpenSearch` 3項目削除、ヘッダーコメントから OpenSearch 参照削除
- `shared/config.nix`: ポート一覧から `opensearch` / `opensearch.transport` / `opensearchDashboards` の3エントリ削除
- `systems/nixos/configurations/g3pro/observability.nix`: コメント整理 (Loki/OpenSearch → Loki / Vector (k3s))
- `systems/darwin/modules/fluent-bit.nix`: 同上
- `systems/nixos/modules/services/desktop-cloudflare-tunnel.nix`: 同上
- `flake.lock`: nixos-observability / nixos-observability-config 更新

## 動作確認
- `nix fmt`: OK
- `nix flake check` (homeMachine + g3pro toplevel build): all checks passed
- `grep -rn opensearch`: 残存ゼロ