### PR TITLE
feat: homeMachine に dotfiles-private 用 self-hosted runner を追加

### DIFF
--- a/secrets/github-runner-private.yaml
+++ b/secrets/github-runner-private.yaml
@@ -1,0 +1,52 @@
+dotfiles_private_runner_token: ENC[AES256_GCM,data:KGd2VrvBpezkfXzthTQx1DDUA3y8vp2O/+ggAsq/5KBBL0RtzkFH8Pug3aR+5xMM1KWpuqZVlkLQrQykFKY33Wyy4qZV1GD+qYyiCjTJBFf1qjkCJ3Qqbirxo0a5,iv:/3AmDf4+7kaK9LFQTGBQA4FKJkIBVJR6OmM05xqYRDo=,tag:N9KeAMvA9Kcpn6pILmBw3w==,type:str]
+sops:
+    age:
+        - recipient: age1p057v4es63p6fef8usy67tkza7dj4xg326w5gm3c7rdthcd3xqlqps38z9
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA0NjBwUWYvbHZIVGY3c3E4
+            NmVqQmhDdDZWejMvUW9JMzI2S2k5M2hkMkU0CkVTVlppWWJ3MUdsRmJISXlJMjZY
+            TDkzN0xsNkI4U1VoZTJscWV6UjBLTlEKLS0tIDJadFU1bG1WVnc2aUl6aFAzR3Bl
+            MUErN081L2IxZjl1UEkzNllXRTVaNlEKCkQWorg5YHi75K/Zv9mbu7g0fLoCoxNm
+            iplswp5CUO3b1Yk9vrKqyTmB8rtN/kjlUcOx/jCj/71QRG4JuYq9tQ==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1tuyn9u7qca3mpk082a94mnwpwgue7wlux2c7mruyxg7fz9y45qrqnqw3yx
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA3VEJld0Z0clhrYXpRdWR3
+            bkNGTEd0NDB5MDhoUG5vdFVjREVia0hpdDFBCm9QSkc0S2lRVEFVTTd4N3FHenFD
+            a0hOU1oxMzA5aEFMK2hNcTRJdlBpR0kKLS0tIEVVK29CQ1k0RnZrcDdzMU9ZeCtp
+            QkxhMXpqbHVKMXJxNXFQVSsxSFEweVUK1aV7MTs4cSxPPdYiZxYkISKsVlHoxNRO
+            +R4FJJiKAefNvQDBSPvlXOau17c1BOOWpIylr+6dA29j2Wno3/3s/A==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age124zeln7fujjzwpaeq2lmg00r93t4kp7tea684yr85prk0zh9jvfqj247af
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZc3hJSlMya2J4TjZ6K0N2
+            aEUyY1Rpb1pCR1pGMStKN2w1LzFrSDRhZ2lzClVsa1VNY2E2ZUFHb3FNaFBBL2RT
+            QkEzWUdLcExvMWJrUEthZ2VjSGZ5djgKLS0tIDFhT1hTeXVwcFhDbGhCV1NHRWQ2
+            bjVGbFRlSHpWeE5FT2RhRTNZMFZoTGMKmVIzXh9LlkKkjppRmvZ2wx/+fsQdBU5F
+            E91UDIIge3utCAcGBqliaJc6zgyquC1qVv44udzFJLteupOLiLKcsg==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1n9tqc8fc5cecey0ca4l2kj74arzl96rnj9kqu02x7amsw2g58erqdcxfpd
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDZ2N3RFNqc2UrRE1zVTk2
+            c0Q5bGlpbk10N2l2dVNHQW45ZzdHUzYzcUdFClcwQ1pVL2I5bHlHMjl2UkppSFpT
+            VDRSRXJPUGZucGc5cW9BL3Y4VUd4NlkKLS0tIDFMM3RhczJ6RVhLdkpZRHVuenl6
+            RzRhcFdFZmNXc1JrOVNzUGc0MVV6MEEKlHbQvEgG6t7ZCXLf4VH3qFEAFzJythmT
+            3Ar2t5zPe792TL3TAPgfjaWn2y4IThE9J0kLsu0zrKhb+/Q9l84meQ==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1sad5k5y967aeq82y6nk5yuzc6cf2fpxxs3y7juf6n3jrcryutgpqwqtt79
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA2UG1HdlNSVksvRS9Xb1J2
+            ajY3YjdIRlZaYzdpTVdpcGVJVklqTEo1Z0RNCnpxZm5JcjFENWM5YktpWVAreHFw
+            UWk5UzJJOWVtM0NMdHJtQWxtUElSMm8KLS0tIFJGOEx2WGVyT0xrV0pqMzZ6K0Nx
+            b1FzZHpwRW4wNWNNU3NCdmVvMFcvM0UKaNcces3OAyhjs61hUTdQzCI2g5RIADHM
+            cnpIJu4YLnDrq6WofaBzxmlRSK8zmxu7Ayx+Y89QupE6A5OdtZH9Ow==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-04-26T11:26:22Z"
+    mac: ENC[AES256_GCM,data:+WN91dazOkIak45xR8eUO33/HIjbiw9y+JbonVegW7co1A/LsEpFPRpyQPHPJErtnXNEFaJJfxyMcNJxS5CQMWMgBZfeUjO64EQQQZLuIl0H1x/gaxH5Vs5iptiLQrHJF2YZTKNsGhwcz4/yvNoKI06CpT/fYUWteSXFBw21W8w=,iv:8z/kOHslIDcXYOT3JxfR+CQfEdeSZ61M4tW+5YzZIYo=,tag:E3ORt4FBAQKLDZcn4moEkQ==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.12.2

--- a/systems/nixos/configurations/homeMachine/default.nix
+++ b/systems/nixos/configurations/homeMachine/default.nix
@@ -24,6 +24,7 @@ in
 
     # ホスト固有の設定
     ./observability.nix
+    ./github-runner.nix
 
     # 基本モジュール
     ../../modules/base.nix

--- a/systems/nixos/configurations/homeMachine/github-runner.nix
+++ b/systems/nixos/configurations/homeMachine/github-runner.nix
@@ -12,17 +12,23 @@
   - ラベルは旧 runner と同一 (`nixos`, `x86_64-linux`) のため workflow 側変更は不要
   - Attic キャッシュ (192.168.1.3:8080) は同一ホスト上にあり、ビルドキャッシュは局所的
 
-  リソース分離方針:
+  リソース分離方針 (homeMachine: 4 cores / 15.5 GB RAM、Grafana 実測ベース):
     homeMachine は k3s control plane / Attic / CNPG / observability などの
     本番サービスを多数抱えているため、runner の CPU / IO / メモリ消費が
     他サービスを圧迫しないよう cgroup レベルで明示的に絞る。
-    - CPUWeight=50 / IOWeight=50: default 100 に対し半分。アイドル時はフルに
-      CPU / IO を使えるが、k3s 等が要求した瞬間に譲る
-    - MemoryHigh=12G / MemoryMax=16G: ソフト+ハードの 2 段
+    24h メモリピーク ~8G / load1 ピーク 9.04 を踏まえ、2 コア + 4G 程度の
+    予算を runner に割り当てる方針。
+    - MemoryMax=4G / MemoryHigh=3G: 4 GB ハード上限 + 3 GB ソフト上限。
+      残り ~12 GB は他サービスとカーネル page cache 用に確保
+    - CPUQuota=200%: 4 cores のうち最大 2 cores を absolute 上限。
+      アイドル時に全コアを食い潰すのを防ぐ
+    - CPUWeight=50: default 100 に対し半分。競合時はさらに譲る
+    - IOWeight=50: 同上、Attic / CNPG WAL flush への波及抑制
     - Nice=10: best-effort スケジュール優先度を下げる
-    - TasksMax=4096: fork bomb 抑止
-    - NIX_CONFIG の cores=4 / max-jobs=2: nix-daemon 経由のビルド本体は
-      runner 外の cgroup で走るため、クライアント側で並列度を絞る hint
+    - TasksMax=2048: fork bomb 抑止
+    - NIX_CONFIG の cores=2 / max-jobs=1: nix-daemon 経由のビルド本体は
+      runner 外の cgroup で走るため、クライアント側 hint で並列度を絞る
+      (1 derivation あたり 2 コアまで、同時 1 derivation のみ)
 */
 {
   config,
@@ -63,24 +69,27 @@
     extraEnvironment = {
       NIX_CONFIG = ''
         experimental-features = nix-command flakes
-        cores = 4
-        max-jobs = 2
+        cores = 2
+        max-jobs = 1
       '';
     };
     serviceOverrides = {
-      # メモリ
-      MemoryMax = "16G";
-      MemoryHigh = "12G";
+      # メモリ (homeMachine 15.5 GB 中 4 GB を runner に割当)
+      MemoryMax = "4G";
+      MemoryHigh = "3G";
 
-      # CPU / IO は他サービスに譲るよう default の半分
+      # CPU (4 cores 中 2 cores を absolute 上限、競合時はさらに譲る)
+      CPUQuota = "200%";
       CPUWeight = 50;
+
+      # IO は proportional yield のみ
       IOWeight = 50;
 
       # スケジュール優先度
       Nice = 10;
 
       # fork bomb / 暴走対策
-      TasksMax = 4096;
+      TasksMax = 2048;
     };
   };
 }

--- a/systems/nixos/configurations/homeMachine/github-runner.nix
+++ b/systems/nixos/configurations/homeMachine/github-runner.nix
@@ -11,6 +11,18 @@
     実行されるため、自己破壊経路は存在しない
   - ラベルは旧 runner と同一 (`nixos`, `x86_64-linux`) のため workflow 側変更は不要
   - Attic キャッシュ (192.168.1.3:8080) は同一ホスト上にあり、ビルドキャッシュは局所的
+
+  リソース分離方針:
+    homeMachine は k3s control plane / Attic / CNPG / observability などの
+    本番サービスを多数抱えているため、runner の CPU / IO / メモリ消費が
+    他サービスを圧迫しないよう cgroup レベルで明示的に絞る。
+    - CPUWeight=50 / IOWeight=50: default 100 に対し半分。アイドル時はフルに
+      CPU / IO を使えるが、k3s 等が要求した瞬間に譲る
+    - MemoryHigh=12G / MemoryMax=16G: ソフト+ハードの 2 段
+    - Nice=10: best-effort スケジュール優先度を下げる
+    - TasksMax=4096: fork bomb 抑止
+    - NIX_CONFIG の cores=4 / max-jobs=2: nix-daemon 経由のビルド本体は
+      runner 外の cgroup で走るため、クライアント側で並列度を絞る hint
 */
 {
   config,
@@ -49,10 +61,26 @@
       openssh
     ];
     extraEnvironment = {
-      NIX_CONFIG = "experimental-features = nix-command flakes";
+      NIX_CONFIG = ''
+        experimental-features = nix-command flakes
+        cores = 4
+        max-jobs = 2
+      '';
     };
     serviceOverrides = {
+      # メモリ
       MemoryMax = "16G";
+      MemoryHigh = "12G";
+
+      # CPU / IO は他サービスに譲るよう default の半分
+      CPUWeight = 50;
+      IOWeight = 50;
+
+      # スケジュール優先度
+      Nice = 10;
+
+      # fork bomb / 暴走対策
+      TasksMax = 4096;
     };
   };
 }

--- a/systems/nixos/configurations/homeMachine/github-runner.nix
+++ b/systems/nixos/configurations/homeMachine/github-runner.nix
@@ -1,0 +1,58 @@
+/*
+  GitHub Actions Self-Hosted Runner 設定 - homeMachine
+
+  dotfiles-private リポジトリ用のセルフホステッドランナーを homeMachine で起動します。
+  従来は nixos-desktop で動作していましたが、deploy-rs が nixos-desktop 自身を
+  再構築する際に runner サービスが再起動して自分自身の job を殺してしまう問題
+  (Issue #639) を解決するため homeMachine へ移設しました。
+
+  - dotfiles-private の deploy 対象は nixos-desktop のみで、homeMachine は対象外
+  - dotfiles (本リポジトリ) の homeMachine deploy は ubuntu-latest + WireGuard 経由で
+    実行されるため、自己破壊経路は存在しない
+  - ラベルは旧 runner と同一 (`nixos`, `x86_64-linux`) のため workflow 側変更は不要
+  - Attic キャッシュ (192.168.1.3:8080) は同一ホスト上にあり、ビルドキャッシュは局所的
+*/
+{
+  config,
+  pkgs,
+  inputs,
+  ...
+}:
+{
+  sops.secrets."dotfiles_private_runner_token" = {
+    sopsFile = "${inputs.self}/secrets/github-runner-private.yaml";
+  };
+
+  services.github-runners.dotfiles-private = {
+    enable = true;
+    url = "https://github.com/shinbunbun/dotfiles-private";
+    tokenFile = config.sops.secrets."dotfiles_private_runner_token".path;
+    name = "homemachine";
+    extraLabels = [
+      "nixos"
+      "x86_64-linux"
+    ];
+    replace = true;
+    ephemeral = true;
+    nodeRuntimes = [ "node20" ];
+    extraPackages = with pkgs; [
+      nix
+      nixfmt-tree
+      git
+      gh
+      bash
+      coreutils
+      gnutar
+      gzip
+      curl
+      jq
+      openssh
+    ];
+    extraEnvironment = {
+      NIX_CONFIG = "experimental-features = nix-command flakes";
+    };
+    serviceOverrides = {
+      MemoryMax = "16G";
+    };
+  };
+}


### PR DESCRIPTION
## 概要

- dotfiles-private 側 Issue #639「self hosted runner 問題の解決」の前半対応
- nixos-desktop で動いていた dotfiles-private 用 self-hosted runner を homeMachine へ移設するための受け側設定を追加
- ラベルは旧 runner と同一 (`nixos`, `x86_64-linux`) のため workflow 側変更不要

## 変更内容

- `secrets/github-runner-private.yaml` を新規追加 (SOPS 暗号化済み、admin / homemachine / nixos-desktop / macmini / g3pro の 5 鍵で復号可能)
- `systems/nixos/configurations/homeMachine/github-runner.nix` を新規追加
- `systems/nixos/configurations/homeMachine/default.nix` の imports に上記 module を追加

## なぜ homeMachine が安全か

- dotfiles-private の deploy 対象は nixos-desktop のみで、homeMachine は対象外
- 本リポジトリの homeMachine deploy は ubuntu-latest + WireGuard 経由で実行され、homeMachine 上の self-hosted runner を経由しない
- → 自己破壊経路は完全に消える
- Attic キャッシュ (192.168.1.3:8080) が同一ホストにあり、ビルドキャッシュの局所性も維持

## cutover 手順

1. (本 PR をマージ) homeMachine を deploy → runner サービスが起動し GitHub Actions runners 画面に `homemachine` (`nixos`, `x86_64-linux`) が出現
2. GitHub UI で旧 nixos-desktop runner を手動 unregister
3. dotfiles-private 側の追従 PR (nixos-desktop の runner module 削除) をマージし、`workflow_dispatch` で deploy.yaml を実行 → homeMachine runner で完走することを確認

## 検証

- `nix fmt`: 差分なし
- `nix flake check`: all checks passed
- `nix build .#nixosConfigurations.homeMachine.config.system.build.toplevel`: 成功
- ビルド成果物に `etc/systemd/system/github-runner-dotfiles-private.service` が含まれることを確認