### PR TITLE
terraform Darwin strip ハング回避 overlay を追加

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -153,6 +153,8 @@
           specialArgs = { inherit inputs; };
           modules = [
             ./systems/darwin/configurations/macbook/default.nix
+            # terraform Darwin strip ハング回避（overlays/terraform-darwin.nix 参照）
+            { nixpkgs.overlays = [ (import ./overlays/terraform-darwin.nix) ]; }
           ];
         };
         macmini = nix-darwin.lib.darwinSystem {
@@ -160,8 +162,14 @@
           specialArgs = { inherit inputs; };
           modules = [
             ./systems/darwin/configurations/macmini/default.nix
-            # MLX Metal GPU有効化（PyPI wheelベース）
-            { nixpkgs.overlays = [ (import ./overlays/mlx-metal.nix) ]; }
+            {
+              nixpkgs.overlays = [
+                # MLX Metal GPU有効化（PyPI wheelベース）
+                (import ./overlays/mlx-metal.nix)
+                # terraform Darwin strip ハング回避（overlays/terraform-darwin.nix 参照）
+                (import ./overlays/terraform-darwin.nix)
+              ];
+            }
           ];
         };
       };

--- a/overlays/terraform-darwin.nix
+++ b/overlays/terraform-darwin.nix
@@ -1,0 +1,29 @@
+/*
+  terraform Darwin strip 回避オーバーレイ
+
+  terraform 1.14.9 (nixpkgs 2026-04-21 バンプ) 以降、Darwin の fixupPhase で
+  llvm-strip が Mach-O export trie のイテレーションで無限ループに陥り、CI が
+  6 時間でタイムアウトする (LLVM Bug 32405 系列の既知バグ)。
+
+  nixpkgs の terraform はすでに `ldflags = ["-s" "-w"]` 付きでビルドされて
+  おり DWARF / シンボルは生成されないため、strip しても削るものがない。
+  そこで Darwin に限り `dontStrip = true` を当て、fixupPhase の strip 呼び出し
+  自体をスキップする。バイナリサイズは変化しない。
+
+  Linux 側では GNU strip が使われ Mach-O export trie 処理を持たないため、
+  本オーバーレイは no-op。
+
+  撤去条件:
+    - nixpkgs の terraform default.nix に Darwin 向け dontStrip が入った時
+    - LLVM 側で Mach-O export trie のループが修正された時
+    - terraform 側で当該パターンを踏まないバージョンが出た時
+*/
+final: prev:
+let
+  inherit (prev) lib stdenv;
+in
+lib.optionalAttrs stdenv.isDarwin {
+  terraform = prev.terraform.overrideAttrs (_: {
+    dontStrip = true;
+  });
+}


### PR DESCRIPTION
## 概要

- terraform 1.14.9 で Darwin の `llvm-strip` が Mach-O export trie の無限ループに入り CI が 6 時間タイムアウトする問題への対処 (LLVM bug #32405 系列)
- Darwin 限定の overlay (`overlays/terraform-darwin.nix`) で `dontStrip = true` を当て、fixupPhase の strip 呼び出しをスキップ
- nixpkgs の terraform は `ldflags = ["-s" "-w"]` でビルド済みのため strip しても削るものがなく、バイナリサイズは変化しない
- `darwinConfigurations.macbook` / `darwinConfigurations.macmini` の両方に適用 (`useGlobalPkgs = true` で home-manager にも overlay が伝搬)
- Linux 側は GNU strip で該当バグなしのため no-op

## 関連

- #635 の `build-darwin (macbook)` / `build-darwin (macmini)` 3 連続タイムアウトを解消する見込み