### PR TITLE
build-darwin に max-jobs=1 を渡して並列ビルド deadlock を回避

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,6 +54,8 @@ jobs:
       needs-sops: true
       needs-wireguard: true
       attic-server: 'http://192.168.1.3:8080'
+      # macos-latest GitHub-hosted runner で並列ビルド deadlock を回避するため serialize
+      max-jobs: '1'
     secrets:
       AUTHENTIK_CLIENT_ID: ${{ secrets.AUTHENTIK_CLIENT_ID }}
       ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}


### PR DESCRIPTION
## 概要

- `ci.yaml` の `build-darwin` job に `max-jobs: '1'` を追加し、Nix を serialize 実行に切り替える
- macos-latest GitHub-hosted runner で `home-manager-agents.drv` 等の並列ビルド時に Nix daemon が次の derivation を schedule できず無限沈黙する deadlock の回避策
- nix-ci-workflows#21 で `max-jobs` input が追加済み (@main で利用可能)

## 背景・検証

PR #635 (Auto-update flake.lock) が build-darwin で 6 時間タイムアウトを 3 連続で起こした問題への対処。徹底的な再現実験で以下を確認:

| 条件 | 所要時間 | 結果 |
|---|---|---|
| 同一 derivation graph + `--max-jobs 1` | 14 分 53 秒 | success (56 derivation 全 build) |
| 同一 derivation graph + `max-jobs=auto` (デフォルト) | 1 時間 45 分以上 | hang (daemon 沈黙、強制 cancel) |

DeterminateSystems/nix-installer#1500・#1479 等で報告のある macos-latest 環境特有の deadlock と整合する。

## 関連

- shinbunbun/nix-ci-workflows#21 (本変更が依存する `max-jobs` input 追加)
- #635 (本対処後に再 CI で通る見込み)