### PR TITLE
direnv Darwin checkPhase 回避 overlay を追加

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -153,8 +153,14 @@
           specialArgs = { inherit inputs; };
           modules = [
             ./systems/darwin/configurations/macbook/default.nix
-            # terraform Darwin strip ハング回避（overlays/terraform-darwin.nix 参照）
-            { nixpkgs.overlays = [ (import ./overlays/terraform-darwin.nix) ]; }
+            {
+              nixpkgs.overlays = [
+                # terraform Darwin strip ハング回避（overlays/terraform-darwin.nix 参照）
+                (import ./overlays/terraform-darwin.nix)
+                # direnv の checkPhase が macos-latest CI で hang する問題を回避
+                (import ./overlays/direnv-darwin-skip-check.nix)
+              ];
+            }
           ];
         };
         macmini = nix-darwin.lib.darwinSystem {
@@ -168,6 +174,8 @@
                 (import ./overlays/mlx-metal.nix)
                 # terraform Darwin strip ハング回避（overlays/terraform-darwin.nix 参照）
                 (import ./overlays/terraform-darwin.nix)
+                # direnv の checkPhase が macos-latest CI で hang する問題を回避
+                (import ./overlays/direnv-darwin-skip-check.nix)
               ];
             }
           ];

--- a/overlays/direnv-darwin-skip-check.nix
+++ b/overlays/direnv-darwin-skip-check.nix
@@ -1,0 +1,28 @@
+/*
+  direnv Darwin checkPhase 回避オーバーレイ
+
+  direnv のテストスイート (test/direnv-test.bash, test/direnv-test.zsh) には
+  シェル間の interactive な動作を含むシナリオが多数あり、macos-latest
+  GitHub-hosted runner で実行すると `Testing base` の `Reloading
+  (should be no-op)` 周辺で確定論的に無限沈黙する。
+
+  ローカルの Mac 実機では通る (deploy-rs で deploy 実績あり) ため、CI 環境
+  特有の問題と考えられる。本番動作には影響しないテストフェーズなので、
+  Darwin に限り doCheck = false を当てて checkPhase 自体をスキップする。
+
+  Linux 側では問題が出ないため no-op。
+
+  撤去条件:
+    - direnv 側 (or nixpkgs 側) で macos GitHub-hosted runner 互換性が
+      改善された時
+    - GitHub-hosted macos-latest 環境が更新されてテストが通るようになった時
+*/
+final: prev:
+let
+  inherit (prev) lib stdenv;
+in
+lib.optionalAttrs stdenv.isDarwin {
+  direnv = prev.direnv.overrideAttrs (_: {
+    doCheck = false;
+  });
+}


### PR DESCRIPTION
## 概要

- direnv の `doCheck = false` を Darwin 限定 overlay として追加 (`overlays/direnv-darwin-skip-check.nix`)
- `darwinConfigurations.macbook` / `macmini` の両方に適用
- パターンは既存の `terraform-darwin.nix` (PR #644) を踏襲

## 背景・検証

PR #635 (Auto-update flake.lock) の `build-darwin` が再び長時間ハング。徹底的な再現実験で以下を確認:

- ハング地点は direnv-2.37.1 の checkPhase
- direnv のテストスイート (`test/direnv-test.bash` / `test/direnv-test.zsh`) のシナリオ `Testing base` の `Reloading (should be no-op)` 周辺で確定論的に無限沈黙
- `--option max-silent-time 600` 付きで再実験したところ `error: building derivation '...direnv-2.37.1.drv' timed out after 600 seconds of silence` を観測 → direnv が真の犯人と特定
- ローカル Mac 実機 (macmini, deploy-rs deploy 実績あり) では正常に通る → CI 環境特有

## 影響範囲

- direnv のパッケージング検証フェーズが Darwin でスキップされる (Linux は影響なし)
- direnv バイナリ自体は通常通り Go ビルドされる ため実害なし

## 関連

- #635 を最終的に通すための対処
- 過去の調査 PR: #644 (terraform overlay), #645 (max-jobs=1)。両者は副次的に効くが今回の direnv hang には不十分だった