### PR TITLE
Revert max-jobs=1: 真の対処は direnv overlay で完結

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,8 +54,6 @@ jobs:
       needs-sops: true
       needs-wireguard: true
       attic-server: 'http://192.168.1.3:8080'
-      # macos-latest GitHub-hosted runner で並列ビルド deadlock を回避するため serialize
-      max-jobs: '1'
     secrets:
       AUTHENTIK_CLIENT_ID: ${{ secrets.AUTHENTIK_CLIENT_ID }}
       ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}


### PR DESCRIPTION
## 概要

- `ci.yaml` の `build-darwin` から `max-jobs: '1'` を削除し、デフォルト (max-jobs=auto) に戻す
- nix-ci-workflows#21 で導入した `max-jobs` input 自体は汎用機能として残す

## 背景

#645 で追加した `max-jobs: '1'` は不要であったことが事後解析で判明:

- #645 の build-darwin が成功した本当の理由は、当時 `direnv-2.37.1` が `cache.nixos.org` から HIT してローカルビルドを回避できていたため (`copying path '/nix/store/...-direnv-2.37.1' from 'https://cache.nixos.org'`)
- max-jobs=1 が並列ビルド deadlock を解消したわけではない
- その後 #635 の新 flake.lock で direnv の derivation hash が変わって cache miss し、ローカルビルド時に checkPhase で確定論的に hang する問題が露呈
- 真の根本原因への対処は #646 で導入済みの direnv Darwin overlay (`doCheck = false`)

## 影響

- build-darwin の所要時間が serialize (15分前後) から並列に戻り、cache hit 多めの場合は 5〜10 分台で完了する想定
- 並列性に伴う潜在的な hang が再発した場合は再度検討