### PR TITLE
flake: nixos-observability-config を 93a48a0 に更新 (fluent-bit Workers=4)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -315,11 +315,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777094401,
-        "narHash": "sha256-KiS/30qRTu1ZWCX3iHeEV9igambnjysR4lKOCo92+QE=",
+        "lastModified": 1777422526,
+        "narHash": "sha256-abuNyl8IH1VDTdAssuOJzwSU4z9gktL38ggI0v6YIX4=",
         "owner": "shinbunbun",
         "repo": "nixos-observability-config",
-        "rev": "490b92e180ed05d44179459d37db8e3f7e29a7d8",
+        "rev": "93a48a058acb4d1b524c54fc228db9568452baf3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## 概要
- `nixos-observability-config` input を 490b92e → 93a48a0 に更新
- 上流変更: fluent-bit forward output に `Workers 4` 追加 (nixos-observability-config#47)
- Vector aggregator への TCP 接続を 1 → 4 に増やし、Cilium maglev の hash 分散を機能させる
- 適用後は homeMachine を `nixos-rebuild switch` で反映、Fluent Bit が Workers=4 で起動することを確認