### PR TITLE
feat(k3s): CoreDNS を replicas=2 で HA 化

### DIFF
--- a/shared/sections/infrastructure.nix
+++ b/shared/sections/infrastructure.nix
@@ -14,6 +14,9 @@ v: {
       servicePool = v.assertString "k3s.cluster.servicePool" "192.168.128.100-192.168.128.200";
       traefikVIP = v.assertIP "k3s.cluster.traefikVIP" "192.168.128.10";
       podCIDR = v.assertCIDR "k3s.cluster.podCIDR" "10.42.0.0/16";
+      coredns = {
+        replicas = v.assertPositiveInt "k3s.cluster.coredns.replicas" 2;
+      };
       bgp = {
         localAS = v.assertPositiveInt "k3s.cluster.bgp.localAS" 65001;
         peerAS = v.assertPositiveInt "k3s.cluster.bgp.peerAS" 65000;

--- a/systems/nixos/modules/k3s.nix
+++ b/systems/nixos/modules/k3s.nix
@@ -10,6 +10,11 @@
   - Cilium: CNI + kube-proxy代替 + BGP Service LB（k8s-apps の ArgoCD Application で管理）
   - DRBD: カーネルレベルストレージレプリケーション（Piraeus Operator経由で管理）
 
+  CoreDNS HA:
+  - k3s 1.25.5+ は CoreDNS Deployment の replicas を hardcode しないため、`kubectl scale` の値が永続化される
+  - clusterInit ノード上で systemd-coredns-scale が k3s 起動後に冪等な scale を実行
+  - k3s 公式マニフェストは既に topologySpreadConstraints (hostname maxSkew=1 DoNotSchedule) を持つので別ノードに分散される
+
   新規クラスタ初期化時の Cilium bootstrap:
   - ArgoCD は Cilium が動いていないと pod を schedule できないため、
     クラスタ初回起動時のみ手動で Cilium をインストールする必要がある
@@ -300,6 +305,41 @@ in
             systemctl restart --no-block k3s.service
           fi
         '';
+    };
+
+    # CoreDNS HA: clusterInit ノードで k3s 起動後に replicas を冪等に scale する
+    # k3s 1.25.5+ (PR #6552) は CoreDNS Deployment の replicas を hardcode しないため、
+    # kubectl scale の値は再起動後も保持される。boot 毎にこのユニットが reconcile する
+    systemd.services.k3s-coredns-scale = lib.mkIf clusterInit {
+      description = "Persist CoreDNS replicas across k3s restarts";
+      after = [ "k3s.service" ];
+      wants = [ "k3s.service" ];
+      wantedBy = [ "multi-user.target" ];
+
+      path = [
+        pkgs.k3s
+        pkgs.coreutils
+      ];
+
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        Restart = "on-failure";
+        RestartSec = "30s";
+        TimeoutStartSec = "600";
+      };
+
+      script = ''
+        export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+        until k3s kubectl cluster-info >/dev/null 2>&1; do
+          sleep 5
+        done
+        until k3s kubectl -n kube-system get deploy coredns >/dev/null 2>&1; do
+          sleep 5
+        done
+        k3s kubectl -n kube-system scale deploy/coredns \
+          --replicas=${toString clusterCfg.coredns.replicas}
+      '';
     };
 
     # k3sツールとkubectl等をシステムパスに追加


### PR DESCRIPTION
## 概要

- `k3s.cluster.coredns.replicas` を `shared/sections/infrastructure.nix` に追加 (デフォルト 2)
- clusterInit ノード (nixos-desktop) で動く `systemd.services.k3s-coredns-scale` を新設し、k3s 起動後に `kubectl scale` で replicas を冪等に reconcile
- `k3s.nix` 冒頭ブロックコメントに CoreDNS HA セクションを追記

## 背景

g3pro 停止時に CoreDNS が単一ノード上の 1 replica だったため、クラスタ全体の DNS 解決が壊れて Authentik 経由の認証 (Grafana 等) が 502 になる事象が発生した。

k3s 1.25.5+ (k3s-io/k3s#6552) は CoreDNS Deployment の replicas を hardcode しないため、`kubectl scale` の値が再起動を跨いで永続化される。topologySpreadConstraints は k3s 公式マニフェストが既に持っている (hostname maxSkew=1 DoNotSchedule) ため追加不要。

PDB は別 PR (k8s-apps) で追加する。
