### PR TITLE
fluent-bit: Vector への接続を Pod 単位 LB の Upstream round-robin に切替

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -315,11 +315,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777422526,
-        "narHash": "sha256-abuNyl8IH1VDTdAssuOJzwSU4z9gktL38ggI0v6YIX4=",
+        "lastModified": 1777446116,
+        "narHash": "sha256-DQae+saT5uQsbN/nweUs4OtlrGEs8N7b2kW+eznpUDQ=",
         "owner": "shinbunbun",
         "repo": "nixos-observability-config",
-        "rev": "93a48a058acb4d1b524c54fc228db9568452baf3",
+        "rev": "820d03d2d457da1f8c00142871b2af2b2a6a7101",
         "type": "github"
       },
       "original": {

--- a/shared/sections/infrastructure.nix
+++ b/shared/sections/infrastructure.nix
@@ -172,7 +172,23 @@ v: {
     k3sPodLogDir = v.assertPath "fluentBit.k3sPodLogDir" "/var/log/pods";
     # Vector (log-archiver-vector) の Fluent Forward エンドポイント。
     # k3s 上の Cilium LB IPAM で固定 VIP (LAN) が割当てられている。
+    # vectorHost/vectorPort は単一 LB (vector-lan, .17) を指す後方互換用。
+    # vectorUpstreams が設定されていれば Fluent Bit は Upstream round-robin
+    # モードで動作し、両 Pod 単位 LB (vector-lan-0=.18 / vector-lan-1=.19)
+    # に flush 単位で均等分散する (Cilium LB の永続接続偏在を回避)。
     vectorHost = v.assertIP "fluentBit.vectorHost" "192.168.128.17";
     vectorPort = v.assertPort "fluentBit.vectorPort" 24224;
+    vectorUpstreams = [
+      {
+        name = "vector-0";
+        host = v.assertIP "fluentBit.vectorUpstreams[0].host" "192.168.128.18";
+        port = v.assertPort "fluentBit.vectorUpstreams[0].port" 24224;
+      }
+      {
+        name = "vector-1";
+        host = v.assertIP "fluentBit.vectorUpstreams[1].host" "192.168.128.19";
+        port = v.assertPort "fluentBit.vectorUpstreams[1].port" 24224;
+      }
+    ];
   };
 }


### PR DESCRIPTION
## 概要
- `shared/sections/infrastructure.nix` の `fluentBit` セクションに `vectorUpstreams` リスト 2 要素を追加 (vector-0=192.168.128.18 / vector-1=192.168.128.19、各 port 24224)
- `flake.lock` の `nixos-observability-config` を 93a48a0 → 820d03d に更新 (Upstream モード対応コードを取り込み)
- 単一 LB (vector-lan, .17) の永続接続では Cilium hash の偏在で片肺集中していた問題への根本対策
- Fluent Bit Upstream の round_robin は接続単位ではなく chunk (flush) 単位で振り分けるため、永続接続でも均等分散が保証される
- 動作確認: `nix flake check` 通過、homeMachine 用 build の fluent-bit.conf に `Upstream` 行と vector-upstream.conf (UPSTREAM/NODE x 2) が正しく生成されることを確認済み
- マージ後は dotfiles-private 側で `nix flake update dotfiles nixos-observability-config` の追随 PR が必要 (Claude が自動作成)