### PR TITLE
overlay(mlx): mlx/mlx-metal を 0.31.2 に bump

### DIFF
--- a/overlays/mlx-metal.nix
+++ b/overlays/mlx-metal.nix
@@ -30,7 +30,7 @@ lib.optionalAttrs isDarwinAarch64 {
 
       mlx =
         let
-          version = "0.30.5";
+          version = "0.31.2";
           platform = "macosx_14_0_arm64";
 
           # Metal GPUバックエンド（libmlx.dylibを含む）
@@ -46,7 +46,7 @@ lib.optionalAttrs isDarwinAarch64 {
               inherit platform;
               python = "py3";
               dist = "py3";
-              hash = "sha256-+Ch9AgQXAjGu/aCwOsuztUM2hIvoPnkW1+8Y1E4jWTo=";
+              hash = "sha256-slOFvO4Y/BlAkiVbi1O5o9hInrZQ5ZFg8bV6rdB6otw=";
             };
 
             dontStrip = true;
@@ -66,7 +66,7 @@ lib.optionalAttrs isDarwinAarch64 {
             python = "cp313";
             dist = "cp313";
             abi = "cp313";
-            hash = "sha256-H9k8495WsBaZ3BipZzyJUQ8XchJfxI9jhdyma+NFAPw=";
+            hash = "sha256-Gz+w3alVsNVSzle91vQrMwmrIbBn5AWH1oSEQ9MH6R8=";
           };
 
           nativeBuildInputs = [ prev.fixDarwinDylibNames ];


### PR DESCRIPTION
## 概要

- `overlays/mlx-metal.nix` で pin している mlx / mlx-metal の PyPI wheel を 0.30.5 → 0.31.2 に bump
- 対応する 2 つの wheel ハッシュも同時更新

## 背景

PR #650 (auto-update flake.lock) の `build-darwin (macmini)` が以下のエラーで失敗:

```
python3.13-mlx-lm>   - mlx>=0.31.2 not satisfied by version 0.30.5
error: Cannot build '...-python3.13-mlx-lm-0.31.3.drv'
```

PR #650 で nixpkgs (`nixpkgs_2`) が bump され mlx-lm が 0.31.3 に上昇。mlx-lm 0.31.3 は `mlx>=0.31.2` を要求するため、overlay 側で 0.30.5 に固定していた mlx と整合しなくなった (`pythonRuntimeDepsCheckHook` で検出)。

PyPI に `mlx-0.31.2-cp313-cp313-macosx_14_0_arm64.whl` および `mlx_metal-0.31.2-py3-none-macosx_14_0_arm64.whl` が揃っているため、両方を 0.31.2 に bump して制約違反を解消する。

## 動作確認

- `nix fmt`: 0 changed
- `nix flake check --no-build`: all checks passed
- `nix eval .#darwinConfigurations.macmini.system.outPath` (Linux 上クロス評価): 成功
- 実ビルドは macmini (aarch64-darwin) CI で確認

## マージ後の作業

PR #650 (auto/update-flake-lock) は本 PR マージ後に rebase または再生成して再 CI を通す。
