### PR TITLE
argocd: repo-server を Burstable QoS 化し probe timeout を 10s に緩和

### DIFF
--- a/shared/sections/services.nix
+++ b/shared/sections/services.nix
@@ -13,6 +13,27 @@ v: {
     ksopsImage = v.assertString "argocd.ksopsImage" "viaductoss/ksops:v4.3.2";
     # k8s専用Age公開鍵（Secret暗号化用、秘密鍵はArgoCD repo-serverのみ保持）
     k8sAgePublicKey = v.assertString "argocd.k8sAgePublicKey" "age1jfkfpwsze8rj0pnzmachzwpqaqk594s7qkazucavues4g499waeqwdkac4";
+
+    # repo-server のリソース要求/上限と probe タイムアウト
+    # BestEffort QoS だとノード逼迫時にスケジューリング優先度が最低となり、
+    # gRPC ヘルスチェック goroutine の wakeup が probe timeoutSeconds を超えて
+    # "Error serving health check request / context canceled" が散発する。
+    # CPU は throttling を避けるため limit を設けず requests のみ指定する。
+    repoServer = {
+      resources = {
+        requests = {
+          cpu = v.assertString "argocd.repoServer.resources.requests.cpu" "100m";
+          memory = v.assertString "argocd.repoServer.resources.requests.memory" "256Mi";
+        };
+        limits = {
+          memory = v.assertString "argocd.repoServer.resources.limits.memory" "512Mi";
+        };
+      };
+      # kubelet probe のタイムアウト秒数（argo-cd Helm chart のデフォルトは
+      # 短く、git fetch 等で一時的に goroutine が遅延すると簡単に超過するため緩和）
+      livenessProbeTimeoutSeconds = v.assertPositiveInt "argocd.repoServer.livenessProbeTimeoutSeconds" 10;
+      readinessProbeTimeoutSeconds = v.assertPositiveInt "argocd.repoServer.readinessProbeTimeoutSeconds" 10;
+    };
   };
 
   ghcr = {

--- a/systems/nixos/modules/services/argocd.nix
+++ b/systems/nixos/modules/services/argocd.nix
@@ -134,6 +134,16 @@ let
       # repo-server のメトリクス (Service のメトリクス port 8084) を有効化
       metrics.enabled = true;
 
+      # BestEffort QoS 脱却（Burstable へ）+ probe タイムアウト緩和
+      # 値は shared/sections/services.nix の argocd.repoServer に集約
+      resources = argocdCfg.repoServer.resources;
+      livenessProbe = {
+        timeoutSeconds = argocdCfg.repoServer.livenessProbeTimeoutSeconds;
+      };
+      readinessProbe = {
+        timeoutSeconds = argocdCfg.repoServer.readinessProbeTimeoutSeconds;
+      };
+
       # KSOPS バイナリをインストールする init container
       initContainers = [
         {


### PR DESCRIPTION
## 概要
- ArgoCD repo-server (nixos-desktop 上) の gRPC ヘルスチェックが2-3時間に1回程度散発的にタイムアウトし `Error serving health check request / context canceled` を出していた問題への対策
- 原因は (1) Pod が BestEffort QoS でノード負荷時のスケジューリング優先度が最低であること、(2) argo-cd Helm chart デフォルトの probe timeoutSeconds (2s/5s) が短く git 操作後の一時的な goroutine 遅延に対応できないこと、(3) ノード `nixos-desktop` 側で散発的な iowait スパイクがエラー時刻と一致すること、の複合
- `argocd.repoServer.resources` を `shared/sections/services.nix` に追加 (requests cpu=100m / mem=256Mi、limits mem=512Mi、CPU limit は throttling 回避のため意図的に設けない)
- `livenessProbe.timeoutSeconds` / `readinessProbe.timeoutSeconds` を 10 秒に統一
- `systems/nixos/modules/services/argocd.nix` の repoServer ブロックで上記値を Helm values に注入