### PR TITLE
fix(authentik): Property Mapping から deprecated な User.ak_groups を排除

### DIFF
--- a/terraform/authentik_property_mappings.tf
+++ b/terraform/authentik_property_mappings.tf
@@ -9,7 +9,7 @@ resource "authentik_property_mapping_provider_scope" "oidc_groups" {
   name       = "OIDC Groups"
   scope_name = "groups"
   expression = <<-EOT
-    return {"groups": [group.name for group in user.ak_groups.all()]}
+    return {"groups": [group.name for group in user.groups.all()]}
   EOT
 }
 
@@ -19,7 +19,7 @@ resource "authentik_property_mapping_provider_scope" "immich_role" {
   scope_name = "immich"
   expression = <<-EOT
     return {
-      "immich_role": "admin" if request.user.ak_groups.filter(name="Immich Admins").exists() else "user"
+      "immich_role": "admin" if request.user.groups.filter(name="Immich Admins").exists() else "user"
     }
   EOT
 }
@@ -32,6 +32,6 @@ resource "authentik_property_mapping_provider_scope" "nextcloud_groups" {
     group_mapping = {
         "Nextcloud Admins": "admin",
     }
-    return {"groups": [group_mapping.get(group.name, group.name) for group in user.ak_groups.all()]}
+    return {"groups": [group_mapping.get(group.name, group.name) for group in user.groups.all()]}
   EOT
 }


### PR DESCRIPTION
## 概要

- OIDC Groups / Immich Role / Nextcloud Groups の3つの Property Mapping で `user.ak_groups.all()` / `request.user.ak_groups.filter(...)` を `user.groups.all()` / `request.user.groups.filter(...)` に置換
- Authentik 公式の deprecation 警告 (`User.ak_groups` → `User.groups`) に従った推奨置換で挙動は等価
- 副次効果として、参照のたびに発火していた `traceback.format_stack()` を含む 70 行 deprecation ログを除去 (klp5x で 24h あたり 990 件 → 0 件想定)
- これに起因していた OIDC discovery のレイテンシ膨張と、Cloudflare/Traefik の 30s 系タイムアウトによる `failed to proxy to backend / context canceled` (Router warn 14件/24h) および asyncio `CancelledError exception in shielded future` (8件/24h) の発生抑制を期待